### PR TITLE
Fix runtime crash

### DIFF
--- a/src/chrome/browser/chrome_content_browser_client.cc
+++ b/src/chrome/browser/chrome_content_browser_client.cc
@@ -1081,9 +1081,8 @@ content::BrowserMainParts* ChromeContentBrowserClient::CreateBrowserMainParts(
   // Construct additional browser parts. Stages are called in the order in
   // which they are added.
 #if defined(TOOLKIT_VIEWS)
-  // Removed !defined(USE_OZONE) for ozone wayland external port
-  // ozone port for wayland should use ChromeBrowserMainExtraPartsViewsLinux
-#if defined(OS_LINUX) && !defined(OS_CHROMEOS)
+#if defined(OZONE_PLATFORM_WAYLAND_EXTERNAL) || \
+    (defined(OS_LINUX) && !defined(OS_CHROMEOS) && !defined(USE_OZONE))
   main_parts->AddParts(new ChromeBrowserMainExtraPartsViewsLinux());
 #else
   main_parts->AddParts(new ChromeBrowserMainExtraPartsViews());

--- a/src/ui/base/ime/input_method_factory.cc
+++ b/src/ui/base/ime/input_method_factory.cc
@@ -19,10 +19,15 @@
 #include "ui/base/ime/input_method_win_tsf.h"
 #elif defined(OS_MACOSX)
 #include "ui/base/ime/input_method_mac.h"
-// Removed defined(USE_X11) for ozone-wayland port
 #elif defined(USE_AURA)
+#if defined(OZONE_PLATFORM_WAYLAND_EXTERNAL)
 #include "ui/base/ime/neva/input_method_auralinux_neva.h"
 #include "ui/base/ime/input_method_auralinux.h"
+#elif (defined(USE_X11) && !defined(USE_OZONE))
+#include "ui/base/ime/input_method_auralinux.h"
+#else
+#include "ui/base/ime/input_method_minimal.h"
+#endif
 #else
 #include "ui/base/ime/input_method_minimal.h"
 #endif
@@ -65,12 +70,17 @@ std::unique_ptr<InputMethod> CreateInputMethod(
   return std::make_unique<InputMethodWin>(delegate, widget);
 #elif defined(OS_MACOSX)
   return std::make_unique<InputMethodMac>(delegate);
-// Removed defined(USE_X11) for ozone-wayland port
 #elif defined(USE_AURA)
+#if defined(OZONE_PLATFORM_WAYLAND_EXTERNAL)
   if (base::CommandLine::ForCurrentProcess()->HasSwitch(switches::kEnableNevaIme))
     return std::make_unique<InputMethodAuraLinuxNeva>(delegate, widget);
   else
     return std::make_unique<InputMethodAuraLinux>(delegate);
+#elif (defined(USE_X11) && !defined(USE_OZONE))
+  return std::make_unique<InputMethodAuraLinux>(delegate);
+#else
+  return std::make_unique<InputMethodMinimal>(delegate);
+#endif
 #else
   return std::make_unique<InputMethodMinimal>(delegate);
 #endif


### PR DESCRIPTION
For now, USE_OZONE will use InputMethodMinimal.