### PR TITLE
Add temporary fix for the null addrinfo

### DIFF
--- a/src/net/dns/host_resolver_proc.cc
+++ b/src/net/dns/host_resolver_proc.cc
@@ -265,6 +265,10 @@ int SystemHostResolverCall(const std::string& host,
     return ERR_NAME_NOT_RESOLVED;
 #endif
 
+// TODO(jkim, msisov): Need to find why |ai| is nullptr.
+  if (ai == nullptr)
+    return ERR_NAME_NOT_RESOLVED;
+
   *addrlist = AddressList::CreateFromAddrinfo(ai);
   freeaddrinfo(ai);
   return OK;


### PR DESCRIPTION
SystemHostResolverCall can't find addrinfo. For temporary fix,
it adds the condition to return if the addrinfo is nullptr.