### PR TITLE
Integrate all the other GPU split patches.

### DIFF
--- a/src/components/viz/host/server_gpu_memory_buffer_manager_unittest.cc
+++ b/src/components/viz/host/server_gpu_memory_buffer_manager_unittest.cc
@@ -15,6 +15,10 @@
 #include "testing/gtest/include/gtest/gtest.h"
 #include "ui/gfx/client_native_pixmap_factory.h"
 
+#if defined(USE_OZONE)
+#include "ui/ozone/public/ozone_platform.h"
+#endif
+
 namespace viz {
 
 namespace {
@@ -157,34 +161,6 @@ class TestGpuService : public mojom::GpuService {
   DISALLOW_COPY_AND_ASSIGN(TestGpuService);
 };
 
-// It is necessary to install a custom pixmap factory which claims to support
-// all native configurations, so that code that deals with this can be tested
-// correctly.
-class FakeClientNativePixmapFactory : public gfx::ClientNativePixmapFactory {
- public:
-  explicit FakeClientNativePixmapFactory(bool allow_native_buffers)
-      : allow_native_buffers_(allow_native_buffers) {}
-  ~FakeClientNativePixmapFactory() override {}
-
-  // gfx::ClientNativePixmapFactory:
-  bool IsConfigurationSupported(gfx::BufferFormat format,
-                                gfx::BufferUsage usage) const override {
-    return allow_native_buffers_;
-  }
-  std::unique_ptr<gfx::ClientNativePixmap> ImportFromHandle(
-      const gfx::NativePixmapHandle& handle,
-      const gfx::Size& size,
-      gfx::BufferUsage usage) override {
-    NOTREACHED();
-    return nullptr;
-  }
-
- private:
-  bool allow_native_buffers_ = false;
-
-  DISALLOW_COPY_AND_ASSIGN(FakeClientNativePixmapFactory);
-};
-
 }  // namespace
 
 class ServerGpuMemoryBufferManagerTest : public ::testing::Test {
@@ -224,32 +200,31 @@ class ServerGpuMemoryBufferManagerTest : public ::testing::Test {
   DISALLOW_COPY_AND_ASSIGN(ServerGpuMemoryBufferManagerTest);
 };
 
-std::unique_ptr<gpu::GpuMemoryBufferSupport> MakeGpuMemoryBufferSupport(
-    bool allow_native_buffers) {
-#if defined(OS_LINUX)
-  return std::make_unique<gpu::GpuMemoryBufferSupport>(
-      std::make_unique<FakeClientNativePixmapFactory>(allow_native_buffers));
-#else
-  return std::make_unique<gpu::GpuMemoryBufferSupport>();
-#endif
-}
-
 // Tests that allocation requests from a client that goes away before allocation
 // completes are cleaned up correctly.
 TEST_F(ServerGpuMemoryBufferManagerTest, AllocationRequestsForDestroyedClient) {
-#if !defined(USE_OZONE) && !defined(OS_MACOSX) && !defined(OS_WIN)
-  // Not all platforms support native configurations (currently only ozone and
-  // mac support it). Abort the test in those platforms.
-  gpu::GpuMemoryBufferSupport support;
-  DCHECK(gpu::GetNativeGpuMemoryBufferConfigurations(&support).empty());
-  return;
-#else
+  bool native_pixmap_supported = false;
+#if defined(USE_OZONE)
+  native_pixmap_supported =
+      ui::OzonePlatform::GetInstance()->IsNativePixmapConfigSupported(
+      gfx::BufferFormat::RGBA_8888, gfx::BufferUsage::GPU_READ);
+#elif defined(OS_MACOSX) || defined(OS_WIN)
+  native_pixmap_supported = true;
+#endif
+
+  if (!native_pixmap_supported) {
+    gpu::GpuMemoryBufferSupport support;
+    DCHECK(gpu::GetNativeGpuMemoryBufferConfigurations(&support).empty());
+    return;
+  }
+
   // Note: ServerGpuMemoryBufferManager normally operates on a mojom::GpuService
   // implementation over mojo. Which means the communication from SGMBManager to
   // GpuService is asynchronous. In this test, the mojom::GpuService is not
   // bound to a mojo pipe, which means those calls are all synchronous.
   TestGpuService gpu_service;
-  auto gpu_memory_buffer_support = MakeGpuMemoryBufferSupport(true);
+  auto gpu_memory_buffer_support =
+      std::make_unique<gpu::GpuMemoryBufferSupport>();
   ServerGpuMemoryBufferManager manager(&gpu_service, 1,
                                        std::move(gpu_memory_buffer_support));
 
@@ -274,13 +249,13 @@ TEST_F(ServerGpuMemoryBufferManagerTest, AllocationRequestsForDestroyedClient) {
   // should request the allocated memory to be freed.
   gpu_service.SatisfyAllocationRequest(buffer_id, client_id);
   EXPECT_TRUE(gpu_service.HasDestructionRequest(buffer_id, client_id));
-#endif
 }
 
 TEST_F(ServerGpuMemoryBufferManagerTest,
        RequestsFromUntrustedClientsValidated) {
   TestGpuService gpu_service;
-  auto gpu_memory_buffer_support = MakeGpuMemoryBufferSupport(false);
+  auto gpu_memory_buffer_support =
+      std::make_unique<gpu::GpuMemoryBufferSupport>();
   ServerGpuMemoryBufferManager manager(&gpu_service, 1,
                                        std::move(gpu_memory_buffer_support));
   const auto buffer_id = static_cast<gfx::GpuMemoryBufferId>(1);
@@ -327,7 +302,8 @@ TEST_F(ServerGpuMemoryBufferManagerTest,
 
 TEST_F(ServerGpuMemoryBufferManagerTest, GpuMemoryBufferDestroyed) {
   TestGpuService gpu_service;
-  auto gpu_memory_buffer_support = MakeGpuMemoryBufferSupport(false);
+  auto gpu_memory_buffer_support =
+      std::make_unique<gpu::GpuMemoryBufferSupport>();
   ServerGpuMemoryBufferManager manager(&gpu_service, 1,
                                        std::move(gpu_memory_buffer_support));
   auto buffer = AllocateGpuMemoryBufferSync(&manager);
@@ -338,7 +314,8 @@ TEST_F(ServerGpuMemoryBufferManagerTest, GpuMemoryBufferDestroyed) {
 TEST_F(ServerGpuMemoryBufferManagerTest,
        GpuMemoryBufferDestroyedOnDifferentThread) {
   TestGpuService gpu_service;
-  auto gpu_memory_buffer_support = MakeGpuMemoryBufferSupport(false);
+  auto gpu_memory_buffer_support =
+      std::make_unique<gpu::GpuMemoryBufferSupport>();
   ServerGpuMemoryBufferManager manager(&gpu_service, 1,
                                        std::move(gpu_memory_buffer_support));
   auto buffer = AllocateGpuMemoryBufferSync(&manager);

--- a/src/content/browser/gpu/gpu_process_host.cc
+++ b/src/content/browser/gpu/gpu_process_host.cc
@@ -766,7 +766,12 @@ void GpuProcessHost::InitOzone() {
   // possible to ensure the latter always has a valid device. crbug.com/608839
   // When running with mus, the OzonePlatform may not have been created yet. So
   // defer the callback until OzonePlatform instance is created.
-  bool using_mojo = true;
+  //
+  // (msisov): this has been changed in the upstream. The ozone initialization was
+  // moved to components/viz/host/gpu_host_impl.cc due to VIZ effort. Thus,
+  // intead of fixing mojo requirement there, do it here. 
+  bool using_mojo = ui::OzonePlatform::GetInstance()
+    ->GetPlatformProperties().requires_mojo;
 #if defined(OS_CHROMEOS)
   using_mojo = features::IsOzoneDrmMojo();
 #endif

--- a/src/gpu/ipc/common/gpu_memory_buffer_support.cc
+++ b/src/gpu/ipc/common/gpu_memory_buffer_support.cc
@@ -20,6 +20,7 @@
 
 #if defined(USE_OZONE)
 #include "ui/ozone/public/client_native_pixmap_factory_ozone.h"
+#include "ui/ozone/public/ozone_platform.h"
 #endif
 
 #if defined(OS_WIN)
@@ -41,13 +42,6 @@ GpuMemoryBufferSupport::GpuMemoryBufferSupport() {
       gfx::CreateClientNativePixmapFactoryDmabuf());
 #endif
 }
-
-#if defined(OS_LINUX) || defined(USE_OZONE)
-GpuMemoryBufferSupport::GpuMemoryBufferSupport(
-    std::unique_ptr<gfx::ClientNativePixmapFactory>
-        client_native_pixmap_factory)
-    : client_native_pixmap_factory_(std::move(client_native_pixmap_factory)) {}
-#endif
 
 GpuMemoryBufferSupport::~GpuMemoryBufferSupport() {}
 
@@ -113,7 +107,8 @@ bool GpuMemoryBufferSupport::IsNativeGpuMemoryBufferConfigurationSupported(
   NOTREACHED();
   return false;
 #elif defined(USE_OZONE)
-  return client_native_pixmap_factory_->IsConfigurationSupported(format, usage);
+  return ui::OzonePlatform::EnsureInstance()->IsNativePixmapConfigSupported(
+      format, usage);
 #elif defined(OS_LINUX)
   return false;  // TODO(julian.isorce): Add linux support.
 #elif defined(OS_WIN)

--- a/src/gpu/ipc/common/gpu_memory_buffer_support.h
+++ b/src/gpu/ipc/common/gpu_memory_buffer_support.h
@@ -29,10 +29,6 @@ namespace gpu {
 class GPU_EXPORT GpuMemoryBufferSupport {
  public:
   GpuMemoryBufferSupport();
-#if defined(OS_LINUX) || defined(USE_OZONE)
-  GpuMemoryBufferSupport(std::unique_ptr<gfx::ClientNativePixmapFactory>
-                             client_native_pixmap_factory);
-#endif
   ~GpuMemoryBufferSupport();
 
   // Returns the native GPU memory buffer factory type. Returns EMPTY_BUFFER

--- a/src/gpu/ipc/service/gpu_init.cc
+++ b/src/gpu/ipc/service/gpu_init.cc
@@ -195,7 +195,11 @@ bool GpuInit::InitializeAndStartSandbox(base::CommandLine* command_line,
   // may also have started at this point.
   ui::OzonePlatform::InitParams params;
   params.single_process = false;
-  params.using_mojo = command_line->HasSwitch(switches::kEnableDrmMojo);
+  params.using_mojo =
+      command_line->HasSwitch(switches::kEnableDrmMojo)
+      || ui::OzonePlatform::EnsureInstance()
+         ->GetPlatformProperties()
+         .requires_mojo;
   ui::OzonePlatform::InitializeForGPU(params);
 #endif
 
@@ -337,7 +341,8 @@ void GpuInit::InitializeInProcess(base::CommandLine* command_line,
   params.using_mojo = base::FeatureList::IsEnabled(features::kMash) ||
                       command_line->HasSwitch(switches::kEnableDrmMojo);
 #else
-  params.using_mojo = command_line->HasSwitch(switches::kEnableDrmMojo);
+  params.using_mojo = ui::OzonePlatform::EnsureInstance()
+                      ->GetPlatformProperties().requires_mojo;
 #endif
   ui::OzonePlatform::InitializeForGPU(params);
   ui::OzonePlatform::GetInstance()->AfterSandboxEntry();

--- a/src/services/service_manager/sandbox/linux/bpf_renderer_policy_linux.cc
+++ b/src/services/service_manager/sandbox/linux/bpf_renderer_policy_linux.cc
@@ -15,7 +15,6 @@
 #include "sandbox/linux/system_headers/linux_syscalls.h"
 #include "services/service_manager/sandbox/linux/sandbox_linux.h"
 
-#if defined(OS_CHROMEOS)
 // TODO(vignatti): replace the local definitions below with #include
 // <linux/dma-buf.h> once kernel version 4.6 becomes widely used.
 #include <linux/types.h>
@@ -26,7 +25,6 @@ struct local_dma_buf_sync {
 #define LOCAL_DMA_BUF_BASE 'b'
 #define LOCAL_DMA_BUF_IOCTL_SYNC \
   _IOW(LOCAL_DMA_BUF_BASE, 0, struct local_dma_buf_sync)
-#endif
 
 using sandbox::SyscallSets;
 using sandbox::bpf_dsl::Allow;
@@ -43,10 +41,8 @@ ResultExpr RestrictIoctl() {
   return Switch(request)
       .SANDBOX_BPF_DSL_CASES((static_cast<unsigned long>(TCGETS), FIONREAD),
                              Allow())
-#if defined(OS_CHROMEOS)
       .SANDBOX_BPF_DSL_CASES(
           (static_cast<unsigned long>(LOCAL_DMA_BUF_IOCTL_SYNC)), Allow())
-#endif
       .Default(sandbox::CrashSIGSYSIoctl());
 }
 

--- a/src/ui/gfx/client_native_pixmap_factory.h
+++ b/src/ui/gfx/client_native_pixmap_factory.h
@@ -25,10 +25,6 @@ class GFX_EXPORT ClientNativePixmapFactory {
  public:
   virtual ~ClientNativePixmapFactory();
 
-  // Returns true if format/usage configuration is supported.
-  virtual bool IsConfigurationSupported(gfx::BufferFormat format,
-                                        gfx::BufferUsage usage) const = 0;
-
   // TODO(dshwang): implement it. crbug.com/475633
   // Import the native pixmap from |handle| to be used in non-GPU processes.
   // This function takes ownership of any file descriptors in |handle|.

--- a/src/ui/gfx/linux/client_native_pixmap_dmabuf.h
+++ b/src/ui/gfx/linux/client_native_pixmap_dmabuf.h
@@ -11,14 +11,19 @@
 
 #include "base/files/scoped_file.h"
 #include "base/macros.h"
+#include "ui/gfx/buffer_types.h"
 #include "ui/gfx/client_native_pixmap.h"
 #include "ui/gfx/geometry/size.h"
+#include "ui/gfx/gfx_export.h"
 #include "ui/gfx/native_pixmap_handle.h"
 
 namespace gfx {
 
 class ClientNativePixmapDmaBuf : public gfx::ClientNativePixmap {
  public:
+  static GFX_EXPORT bool IsConfigurationSupported(gfx::BufferFormat format,
+                                                  gfx::BufferUsage usage);
+
   static std::unique_ptr<gfx::ClientNativePixmap> ImportFromDmabuf(
       const gfx::NativePixmapHandle& handle,
       const gfx::Size& size);

--- a/src/ui/gfx/linux/client_native_pixmap_factory_dmabuf.cc
+++ b/src/ui/gfx/linux/client_native_pixmap_factory_dmabuf.cc
@@ -45,79 +45,9 @@ class ClientNativePixmapOpaque : public ClientNativePixmap {
 
 class ClientNativePixmapFactoryDmabuf : public ClientNativePixmapFactory {
  public:
-  explicit ClientNativePixmapFactoryDmabuf(
-      bool supports_native_pixmap_import_from_dmabuf)
-      : supports_native_pixmap_import_from_dmabuf_(
-            supports_native_pixmap_import_from_dmabuf) {}
+  explicit ClientNativePixmapFactoryDmabuf() {}
   ~ClientNativePixmapFactoryDmabuf() override {}
 
-  // ClientNativePixmapFactory:
-  bool IsConfigurationSupported(gfx::BufferFormat format,
-                                gfx::BufferUsage usage) const override {
-    switch (usage) {
-      case gfx::BufferUsage::GPU_READ:
-        return format == gfx::BufferFormat::BGR_565 ||
-               format == gfx::BufferFormat::RGBA_8888 ||
-               format == gfx::BufferFormat::RGBX_8888 ||
-               format == gfx::BufferFormat::BGRA_8888 ||
-               format == gfx::BufferFormat::BGRX_8888 ||
-               format == gfx::BufferFormat::YVU_420;
-      case gfx::BufferUsage::SCANOUT:
-        return format == gfx::BufferFormat::BGRX_8888 ||
-               format == gfx::BufferFormat::RGBX_8888 ||
-               format == gfx::BufferFormat::RGBA_8888 ||
-               format == gfx::BufferFormat::BGRA_8888;
-      case gfx::BufferUsage::SCANOUT_CPU_READ_WRITE:
-        return
-#if defined(ARCH_CPU_X86_FAMILY)
-            // Currently only Intel driver (i.e. minigbm and Mesa) supports R_8
-            // RG_88 and NV12. https://crbug.com/356871
-            format == gfx::BufferFormat::R_8 ||
-            format == gfx::BufferFormat::RG_88 ||
-            format == gfx::BufferFormat::YUV_420_BIPLANAR ||
-#endif
-
-            format == gfx::BufferFormat::BGRX_8888 ||
-            format == gfx::BufferFormat::BGRA_8888 ||
-            format == gfx::BufferFormat::RGBX_8888 ||
-            format == gfx::BufferFormat::RGBA_8888;
-      case gfx::BufferUsage::SCANOUT_VDA_WRITE:
-        return false;
-      case gfx::BufferUsage::GPU_READ_CPU_READ_WRITE:
-      case gfx::BufferUsage::GPU_READ_CPU_READ_WRITE_PERSISTENT: {
-        if (!supports_native_pixmap_import_from_dmabuf_)
-          return false;
-        return
-#if defined(ARCH_CPU_X86_FAMILY)
-            // Currently only Intel driver (i.e. minigbm and
-            // Mesa) supports R_8 RG_88 and NV12.
-            // https://crbug.com/356871
-            format == gfx::BufferFormat::R_8 ||
-            format == gfx::BufferFormat::RG_88 ||
-            format == gfx::BufferFormat::YUV_420_BIPLANAR ||
-#endif
-            format == gfx::BufferFormat::BGRA_8888;
-      }
-      case gfx::BufferUsage::SCANOUT_CAMERA_READ_WRITE: {
-        if (!supports_native_pixmap_import_from_dmabuf_)
-          return false;
-        // Each platform only supports one camera buffer type. We list the
-        // supported buffer formats on all platforms here. When allocating a
-        // camera buffer the caller is responsible for making sure a buffer is
-        // successfully allocated. For example, allocating YUV420_BIPLANAR
-        // for SCANOUT_CAMERA_READ_WRITE may only work on Intel boards.
-        return format == gfx::BufferFormat::YUV_420_BIPLANAR;
-      }
-      case gfx::BufferUsage::CAMERA_AND_CPU_READ_WRITE: {
-        if (!supports_native_pixmap_import_from_dmabuf_)
-          return false;
-        // R_8 is used as the underlying pixel format for BLOB buffers.
-        return format == gfx::BufferFormat::R_8;
-      }
-    }
-    NOTREACHED();
-    return false;
-  }
   std::unique_ptr<ClientNativePixmap> ImportFromHandle(
       const gfx::NativePixmapHandle& handle,
       const gfx::Size& size,
@@ -129,11 +59,7 @@ class ClientNativePixmapFactoryDmabuf : public ClientNativePixmapFactory {
       case gfx::BufferUsage::GPU_READ_CPU_READ_WRITE_PERSISTENT:
       case gfx::BufferUsage::SCANOUT_CAMERA_READ_WRITE:
       case gfx::BufferUsage::CAMERA_AND_CPU_READ_WRITE:
-        if (supports_native_pixmap_import_from_dmabuf_)
-          return ClientNativePixmapDmaBuf::ImportFromDmabuf(handle, size);
-        NOTREACHED()
-            << "Native GpuMemoryBuffers are not supported on this platform";
-        return nullptr;
+        return ClientNativePixmapDmaBuf::ImportFromDmabuf(handle, size);
       case gfx::BufferUsage::GPU_READ:
       case gfx::BufferUsage::SCANOUT:
       case gfx::BufferUsage::SCANOUT_VDA_WRITE:
@@ -147,30 +73,11 @@ class ClientNativePixmapFactoryDmabuf : public ClientNativePixmapFactory {
   }
 
  private:
-  // Says if ClientNativePixmapDmaBuf can be used to import handle from dmabuf.
-  const bool supports_native_pixmap_import_from_dmabuf_ = false;
-
   DISALLOW_COPY_AND_ASSIGN(ClientNativePixmapFactoryDmabuf);
 };
 
-ClientNativePixmapFactory* CreateClientNativePixmapFactoryDmabuf(
-    bool supports_native_pixmap_import_from_dmabuf) {
-// |supports_native_pixmap_import_from_dmabuf| can be enabled on all linux but
-// it is not a requirement to support glCreateImageChromium+Dmabuf since it uses
-// gfx::BufferUsage::SCANOUT and the pixmap does not need to be mappable on the
-// client side.
-//
-// At the moment, only Ozone/Wayland platform running on Linux is able to import
-// handle from dmabuf in addition to the ChromeOS. This is set in the ozone
-// level in the ClientNativePixmapFactoryWayland class.
-//
-// This is not ideal. The ozone platform should probably set this.
-// TODO(rjkroege): do something better here.
-#if defined(OS_CHROMEOS)
-  supports_native_pixmap_import_from_dmabuf = true;
-#endif
-  return new ClientNativePixmapFactoryDmabuf(
-      supports_native_pixmap_import_from_dmabuf);
+ClientNativePixmapFactory* CreateClientNativePixmapFactoryDmabuf() {
+  return new ClientNativePixmapFactoryDmabuf();
 }
 
 }  // namespace gfx

--- a/src/ui/gfx/linux/client_native_pixmap_factory_dmabuf.cc
+++ b/src/ui/gfx/linux/client_native_pixmap_factory_dmabuf.cc
@@ -12,12 +12,10 @@
 #include "build/build_config.h"
 #include "ui/gfx/native_pixmap_handle.h"
 
-#if defined(OS_CHROMEOS)
-// This can be enabled on all linux but it is not a requirement to support
-// glCreateImageChromium+Dmabuf since it uses gfx::BufferUsage::SCANOUT and
-// the pixmap does not need to be mappable on the client side.
+// Although, it's compiled for all linux platforms, it does not mean dmabuf
+// will work there. Check the comment below in the
+// ClientNativePixmapFactoryDmabuf for more details.
 #include "ui/gfx/linux/client_native_pixmap_dmabuf.h"
-#endif
 
 namespace gfx {
 
@@ -47,7 +45,10 @@ class ClientNativePixmapOpaque : public ClientNativePixmap {
 
 class ClientNativePixmapFactoryDmabuf : public ClientNativePixmapFactory {
  public:
-  ClientNativePixmapFactoryDmabuf() {}
+  explicit ClientNativePixmapFactoryDmabuf(
+      bool supports_native_pixmap_import_from_dmabuf)
+      : supports_native_pixmap_import_from_dmabuf_(
+            supports_native_pixmap_import_from_dmabuf) {}
   ~ClientNativePixmapFactoryDmabuf() override {}
 
   // ClientNativePixmapFactory:
@@ -84,39 +85,34 @@ class ClientNativePixmapFactoryDmabuf : public ClientNativePixmapFactory {
         return false;
       case gfx::BufferUsage::GPU_READ_CPU_READ_WRITE:
       case gfx::BufferUsage::GPU_READ_CPU_READ_WRITE_PERSISTENT: {
-#if defined(OS_CHROMEOS)
+        if (!supports_native_pixmap_import_from_dmabuf_)
+          return false;
         return
 #if defined(ARCH_CPU_X86_FAMILY)
-            // Currently only Intel driver (i.e. minigbm and Mesa) supports R_8
-            // RG_88 and NV12. https://crbug.com/356871
+            // Currently only Intel driver (i.e. minigbm and
+            // Mesa) supports R_8 RG_88 and NV12.
+            // https://crbug.com/356871
             format == gfx::BufferFormat::R_8 ||
             format == gfx::BufferFormat::RG_88 ||
             format == gfx::BufferFormat::YUV_420_BIPLANAR ||
 #endif
             format == gfx::BufferFormat::BGRA_8888;
-#else
-        return false;
-#endif
       }
       case gfx::BufferUsage::SCANOUT_CAMERA_READ_WRITE: {
-#if defined(OS_CHROMEOS)
+        if (!supports_native_pixmap_import_from_dmabuf_)
+          return false;
         // Each platform only supports one camera buffer type. We list the
         // supported buffer formats on all platforms here. When allocating a
         // camera buffer the caller is responsible for making sure a buffer is
         // successfully allocated. For example, allocating YUV420_BIPLANAR
         // for SCANOUT_CAMERA_READ_WRITE may only work on Intel boards.
         return format == gfx::BufferFormat::YUV_420_BIPLANAR;
-#else
-        return false;
-#endif
       }
       case gfx::BufferUsage::CAMERA_AND_CPU_READ_WRITE: {
-#if defined(OS_CHROMEOS)
+        if (!supports_native_pixmap_import_from_dmabuf_)
+          return false;
         // R_8 is used as the underlying pixel format for BLOB buffers.
         return format == gfx::BufferFormat::R_8;
-#else
-        return false;
-#endif
       }
     }
     NOTREACHED();
@@ -133,12 +129,11 @@ class ClientNativePixmapFactoryDmabuf : public ClientNativePixmapFactory {
       case gfx::BufferUsage::GPU_READ_CPU_READ_WRITE_PERSISTENT:
       case gfx::BufferUsage::SCANOUT_CAMERA_READ_WRITE:
       case gfx::BufferUsage::CAMERA_AND_CPU_READ_WRITE:
-#if defined(OS_CHROMEOS)
-        return ClientNativePixmapDmaBuf::ImportFromDmabuf(handle, size);
-#else
-        NOTREACHED();
+        if (supports_native_pixmap_import_from_dmabuf_)
+          return ClientNativePixmapDmaBuf::ImportFromDmabuf(handle, size);
+        NOTREACHED()
+            << "Native GpuMemoryBuffers are not supported on this platform";
         return nullptr;
-#endif
       case gfx::BufferUsage::GPU_READ:
       case gfx::BufferUsage::SCANOUT:
       case gfx::BufferUsage::SCANOUT_VDA_WRITE:
@@ -151,11 +146,31 @@ class ClientNativePixmapFactoryDmabuf : public ClientNativePixmapFactory {
     return nullptr;
   }
 
+ private:
+  // Says if ClientNativePixmapDmaBuf can be used to import handle from dmabuf.
+  const bool supports_native_pixmap_import_from_dmabuf_ = false;
+
   DISALLOW_COPY_AND_ASSIGN(ClientNativePixmapFactoryDmabuf);
 };
 
-ClientNativePixmapFactory* CreateClientNativePixmapFactoryDmabuf() {
-  return new ClientNativePixmapFactoryDmabuf();
+ClientNativePixmapFactory* CreateClientNativePixmapFactoryDmabuf(
+    bool supports_native_pixmap_import_from_dmabuf) {
+// |supports_native_pixmap_import_from_dmabuf| can be enabled on all linux but
+// it is not a requirement to support glCreateImageChromium+Dmabuf since it uses
+// gfx::BufferUsage::SCANOUT and the pixmap does not need to be mappable on the
+// client side.
+//
+// At the moment, only Ozone/Wayland platform running on Linux is able to import
+// handle from dmabuf in addition to the ChromeOS. This is set in the ozone
+// level in the ClientNativePixmapFactoryWayland class.
+//
+// This is not ideal. The ozone platform should probably set this.
+// TODO(rjkroege): do something better here.
+#if defined(OS_CHROMEOS)
+  supports_native_pixmap_import_from_dmabuf = true;
+#endif
+  return new ClientNativePixmapFactoryDmabuf(
+      supports_native_pixmap_import_from_dmabuf);
 }
 
 }  // namespace gfx

--- a/src/ui/gfx/linux/client_native_pixmap_factory_dmabuf.h
+++ b/src/ui/gfx/linux/client_native_pixmap_factory_dmabuf.h
@@ -10,8 +10,7 @@
 
 namespace gfx {
 
-GFX_EXPORT ClientNativePixmapFactory* CreateClientNativePixmapFactoryDmabuf(
-    bool supports_import_from_dmabuf = false);
+GFX_EXPORT ClientNativePixmapFactory* CreateClientNativePixmapFactoryDmabuf();
 
 }  // namespace gfx
 

--- a/src/ui/gfx/linux/client_native_pixmap_factory_dmabuf.h
+++ b/src/ui/gfx/linux/client_native_pixmap_factory_dmabuf.h
@@ -10,7 +10,8 @@
 
 namespace gfx {
 
-GFX_EXPORT ClientNativePixmapFactory* CreateClientNativePixmapFactoryDmabuf();
+GFX_EXPORT ClientNativePixmapFactory* CreateClientNativePixmapFactoryDmabuf(
+    bool supports_import_from_dmabuf = false);
 
 }  // namespace gfx
 

--- a/src/ui/gfx/mojo/BUILD.gn
+++ b/src/ui/gfx/mojo/BUILD.gn
@@ -13,12 +13,14 @@ mojom("mojo") {
     "gpu_fence_handle.mojom",
     "icc_profile.mojom",
     "overlay_transform.mojom",
+    "presentation_feedback.mojom",
     "selection_bound.mojom",
     "swap_result.mojom",
     "transform.mojom",
   ]
 
   public_deps = [
+    "//mojo/public/mojom/base",
     "//ui/gfx/geometry/mojo",
   ]
 }

--- a/src/ui/gfx/mojo/BUILD.gn
+++ b/src/ui/gfx/mojo/BUILD.gn
@@ -14,6 +14,7 @@ mojom("mojo") {
     "icc_profile.mojom",
     "overlay_transform.mojom",
     "selection_bound.mojom",
+    "swap_result.mojom",
     "transform.mojom",
   ]
 

--- a/src/ui/gfx/mojo/presentation_feedback.mojom
+++ b/src/ui/gfx/mojo/presentation_feedback.mojom
@@ -1,0 +1,14 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+module gfx.mojom;
+
+import "mojo/public/mojom/base/time.mojom";
+
+// gfx::PresentationFeedback
+struct PresentationFeedback {
+  mojo_base.mojom.TimeTicks timestamp;
+  mojo_base.mojom.TimeDelta interval;
+  uint32 flags;
+};

--- a/src/ui/gfx/mojo/presentation_feedback.typemap
+++ b/src/ui/gfx/mojo/presentation_feedback.typemap
@@ -1,0 +1,8 @@
+# Copyright 2018 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+mojom = "//ui/gfx/mojo/presentation_feedback.mojom"
+public_headers = [ "//ui/gfx/presentation_feedback.h" ]
+traits_headers = [ "//ui/gfx/mojo/presentation_feedback_struct_traits.h" ]
+type_mappings = [ "gfx.mojom.PresentationFeedback=gfx::PresentationFeedback" ]

--- a/src/ui/gfx/mojo/presentation_feedback_struct_traits.h
+++ b/src/ui/gfx/mojo/presentation_feedback_struct_traits.h
@@ -1,0 +1,40 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef UI_GFX_MOJO_PRESENTATION_FEEDBACK_STRUCT_TRAITS_H_
+#define UI_GFX_MOJO_PRESENTATION_FEEDBACK_STRUCT_TRAITS_H_
+
+#include "base/time/time.h"
+#include "mojo/public/cpp/base/time_mojom_traits.h"
+#include "ui/gfx/mojo/presentation_feedback.mojom-shared.h"
+#include "ui/gfx/presentation_feedback.h"
+
+namespace mojo {
+
+template <>
+struct StructTraits<gfx::mojom::PresentationFeedbackDataView,
+                    gfx::PresentationFeedback> {
+  static base::TimeTicks timestamp(const gfx::PresentationFeedback& input) {
+    return input.timestamp;
+  }
+
+  static base::TimeDelta interval(const gfx::PresentationFeedback& input) {
+    return input.interval;
+  }
+
+  static uint32_t flags(const gfx::PresentationFeedback& input) {
+    return input.flags;
+  }
+
+  static bool Read(gfx::mojom::PresentationFeedbackDataView data,
+                   gfx::PresentationFeedback* out) {
+    out->flags = data.flags();
+    return data.ReadTimestamp(&out->timestamp) &&
+           data.ReadInterval(&out->interval);
+  }
+};
+
+}  // namespace mojo
+
+#endif  // UI_GFX_MOJO_PRESENTATION_FEEDBACK_STRUCT_TRAITS_H_

--- a/src/ui/gfx/mojo/swap_result.mojom
+++ b/src/ui/gfx/mojo/swap_result.mojom
@@ -1,0 +1,16 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+module gfx.mojom;
+
+// SwapResult information which is used to indicate whether buffer swap
+// succeeded or not. These values correspond to gfx::SwapResult values in
+// ui/gfx/swap_result.h. Currently, it is used by the Ozone/Wayland to identify
+// whether a buffer swap requested by the GPU process has been successful on
+// the browser process side or not.
+enum SwapResult {
+  ACK,
+  FAILED,
+  NAK_RECREATE_BUFFERS,
+};

--- a/src/ui/gfx/mojo/swap_result.typemap
+++ b/src/ui/gfx/mojo/swap_result.typemap
@@ -1,0 +1,8 @@
+# Copyright 2018 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+mojom = "//ui/gfx/mojo/swap_result.mojom"
+public_headers = [ "//ui/gfx/swap_result.h" ]
+traits_headers = [ "//ui/gfx/mojo/swap_result_enum_traits.h" ]
+type_mappings = [ "gfx.mojom.SwapResult=gfx::SwapResult" ]

--- a/src/ui/gfx/mojo/swap_result_enum_traits.h
+++ b/src/ui/gfx/mojo/swap_result_enum_traits.h
@@ -1,0 +1,48 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef UI_GFX_MOJO_SWAP_RESULT_ENUM_TRAITS_H_
+#define UI_GFX_MOJO_SWAP_RESULT_ENUM_TRAITS_H_
+
+#include "mojo/public/cpp/bindings/enum_traits.h"
+#include "ui/gfx/mojo/swap_result.mojom-shared.h"
+#include "ui/gfx/swap_result.h"
+
+namespace mojo {
+
+template <>
+struct EnumTraits<gfx::mojom::SwapResult, gfx::SwapResult> {
+  static gfx::mojom::SwapResult ToMojom(gfx::SwapResult input) {
+    switch (input) {
+      case gfx::SwapResult::SWAP_ACK:
+        return gfx::mojom::SwapResult::ACK;
+      case gfx::SwapResult::SWAP_FAILED:
+        return gfx::mojom::SwapResult::FAILED;
+      case gfx::SwapResult::SWAP_NAK_RECREATE_BUFFERS:
+        return gfx::mojom::SwapResult::NAK_RECREATE_BUFFERS;
+    }
+    NOTREACHED();
+    return gfx::mojom::SwapResult::FAILED;
+  }
+
+  static bool FromMojom(gfx::mojom::SwapResult input, gfx::SwapResult* out) {
+    switch (input) {
+      case gfx::mojom::SwapResult::ACK:
+        *out = gfx::SwapResult::SWAP_ACK;
+        return true;
+      case gfx::mojom::SwapResult::FAILED:
+        *out = gfx::SwapResult::SWAP_FAILED;
+        return true;
+      case gfx::mojom::SwapResult::NAK_RECREATE_BUFFERS:
+        *out = gfx::SwapResult::SWAP_NAK_RECREATE_BUFFERS;
+        return true;
+    }
+    NOTREACHED();
+    return false;
+  }
+};
+
+}  // namespace mojo
+
+#endif  // UI_GFX_MOJO_SWAP_RESULT_ENUM_TRAITS_H_

--- a/src/ui/gfx/typemaps.gni
+++ b/src/ui/gfx/typemaps.gni
@@ -12,6 +12,7 @@ typemaps = [
   "//ui/gfx/mojo/gpu_fence_handle.typemap",
   "//ui/gfx/mojo/icc_profile.typemap",
   "//ui/gfx/mojo/overlay_transform.typemap",
+  "//ui/gfx/mojo/presentation_feedback.typemap",
   "//ui/gfx/mojo/swap_result.typemap",
   "//ui/gfx/mojo/selection_bound.typemap",
   "//ui/gfx/mojo/transform.typemap",

--- a/src/ui/gfx/typemaps.gni
+++ b/src/ui/gfx/typemaps.gni
@@ -12,6 +12,7 @@ typemaps = [
   "//ui/gfx/mojo/gpu_fence_handle.typemap",
   "//ui/gfx/mojo/icc_profile.typemap",
   "//ui/gfx/mojo/overlay_transform.typemap",
+  "//ui/gfx/mojo/swap_result.typemap",
   "//ui/gfx/mojo/selection_bound.typemap",
   "//ui/gfx/mojo/transform.typemap",
   "//ui/gfx/range/mojo/range.typemap",

--- a/src/ui/ozone/common/linux/BUILD.gn
+++ b/src/ui/ozone/common/linux/BUILD.gn
@@ -7,16 +7,28 @@ import("//ui/ozone/ozone.gni")
 
 assert(ozone_platform_gbm || ozone_platform_wayland)
 
-source_set("linux") {
+source_set("drm") {
   sources = [
     "drm_util_linux.cc",
     "drm_util_linux.h",
+  ]
+
+  deps = [
+    "//base:base",
+    "//third_party/libdrm",
+    "//ui/gfx:buffer_types",
+  ]
+}
+
+source_set("gbm") {
+  sources = [
     "gbm_buffer.h",
     "gbm_device.h",
     "gbm_wrapper.cc",
   ]
 
   deps = [
+    ":drm",
     "//base:base",
     "//third_party/libdrm",
     "//third_party/minigbm",

--- a/src/ui/ozone/common/linux/drm_util_linux.cc
+++ b/src/ui/ozone/common/linux/drm_util_linux.cc
@@ -71,19 +71,19 @@ gfx::BufferFormat GetBufferFormatFromFourCCFormat(int format) {
 }
 
 bool IsValidBufferFormat(uint32_t current_format) {
-  switch (GetBufferFormatFromFourCCFormat(current_format)) {
-    case gfx::BufferFormat::R_8:
-    case gfx::BufferFormat::RG_88:
-    case gfx::BufferFormat::RGBA_8888:
-    case gfx::BufferFormat::RGBX_8888:
-    case gfx::BufferFormat::BGRA_8888:
-    case gfx::BufferFormat::BGRX_8888:
-    case gfx::BufferFormat::BGRX_1010102:
-    case gfx::BufferFormat::RGBX_1010102:
-    case gfx::BufferFormat::BGR_565:
-    case gfx::BufferFormat::UYVY_422:
-    case gfx::BufferFormat::YUV_420_BIPLANAR:
-    case gfx::BufferFormat::YVU_420:
+  switch (current_format) {
+    case DRM_FORMAT_R8:
+    case DRM_FORMAT_GR88:
+    case DRM_FORMAT_ABGR8888:
+    case DRM_FORMAT_XBGR8888:
+    case DRM_FORMAT_ARGB8888:
+    case DRM_FORMAT_XRGB8888:
+    case DRM_FORMAT_XRGB2101010:
+    case DRM_FORMAT_XBGR2101010:
+    case DRM_FORMAT_RGB565:
+    case DRM_FORMAT_UYVY:
+    case DRM_FORMAT_NV12:
+    case DRM_FORMAT_YVU420:
       return true;
     default:
       return false;

--- a/src/ui/ozone/common/linux/gbm_wrapper.cc
+++ b/src/ui/ozone/common/linux/gbm_wrapper.cc
@@ -14,6 +14,14 @@
 
 namespace gbm_wrapper {
 
+namespace {
+
+// Temporary defines while we migrate to GBM_BO_IMPORT_FD_MODIFIER.
+#define GBM_BO_IMPORT_FD_PLANAR_5504 0x5504
+#define GBM_BO_IMPORT_FD_PLANAR_5505 0x5505
+
+}  // namespace
+
 class Buffer final : public ui::GbmBuffer {
  public:
   Buffer(struct gbm_bo* bo,
@@ -206,10 +214,17 @@ class Device final : public ui::GbmDevice {
 
       // The fd passed to gbm_bo_import is not ref-counted and need to be
       // kept open for the lifetime of the buffer.
-      bo = gbm_bo_import(device_, GBM_BO_IMPORT_FD_PLANAR, &fd_data, gbm_flags);
+      //
+      // See the comment regarding the GBM_BO_IMPORT_FD_PLANAR_550X above.
+      bo = gbm_bo_import(device_, GBM_BO_IMPORT_FD_PLANAR_5505, &fd_data,
+                         gbm_flags);
       if (!bo) {
-        LOG(ERROR) << "nullptr returned from gbm_bo_import";
-        return nullptr;
+        bo = gbm_bo_import(device_, GBM_BO_IMPORT_FD_PLANAR_5504, &fd_data,
+                           gbm_flags);
+        if (!bo) {
+          LOG(ERROR) << "nullptr returned from gbm_bo_import";
+          return nullptr;
+        }
       }
     }
 

--- a/src/ui/ozone/common/linux/gbm_wrapper.cc
+++ b/src/ui/ozone/common/linux/gbm_wrapper.cc
@@ -4,7 +4,10 @@
 
 #include "ui/ozone/common/linux/gbm_wrapper.h"
 
+#include <drm_fourcc.h>
+#include <fcntl.h>
 #include <gbm.h>
+#include <xf86drm.h>
 
 #include "base/posix/eintr_wrapper.h"
 #include "ui/gfx/buffer_format_util.h"
@@ -19,6 +22,48 @@ namespace {
 // Temporary defines while we migrate to GBM_BO_IMPORT_FD_MODIFIER.
 #define GBM_BO_IMPORT_FD_PLANAR_5504 0x5504
 #define GBM_BO_IMPORT_FD_PLANAR_5505 0x5505
+
+int GetPlaneFdForBo(gbm_bo* bo, size_t plane) {
+#if defined(MINIGBM)
+  return gbm_bo_get_plane_fd(bo, plane);
+#else
+  const int plane_count = gbm_bo_get_plane_count(bo);
+  DCHECK(plane_count > 0 && plane < static_cast<size_t>(plane_count));
+
+  // System linux gbm (or Mesa gbm) does not provide fds per plane basis. Thus,
+  // get plane handle and use drm ioctl to get a prime fd out of it avoid having
+  // two different branches for minigbm and Mesa gbm here.
+  gbm_device* gbm_dev = gbm_bo_get_device(bo);
+  int dev_fd = gbm_device_get_fd(gbm_dev);
+  DCHECK_GE(dev_fd, 0);
+
+  const uint32_t plane_handle = gbm_bo_get_handle_for_plane(bo, plane).u32;
+  int fd = -1;
+  int ret;
+  // Use DRM_RDWR to allow the fd to be mappable in another process.
+  ret = drmPrimeHandleToFD(dev_fd, plane_handle, DRM_CLOEXEC | DRM_RDWR, &fd);
+
+  // Older DRM implementations blocked DRM_RDWR, but gave a read/write mapping
+  // anyways
+  if (ret)
+    ret = drmPrimeHandleToFD(dev_fd, plane_handle, DRM_CLOEXEC, &fd);
+
+  return ret ? ret : fd;
+#endif
+}
+
+size_t GetSizeOfPlane(gbm_bo* bo, size_t plane) {
+#if defined(MINIGBM)
+  return gbm_bo_get_plane_size(bo, plane);
+#else
+  // System linux gbm (or Mesa gbm) does not provide plane size. Thus, calculate
+  // it by ourselves and avoid having two different branches for minigbm and
+  // Mesa gbm here.
+  //
+  // TODO(msisov): Handle subsampled formats
+  return gbm_bo_get_height(bo) * gbm_bo_get_stride_for_plane(bo, plane);
+#endif
+}
 
 }  // namespace
 
@@ -80,7 +125,7 @@ class Buffer final : public ui::GbmBuffer {
   }
   uint32_t GetPlaneHandle(size_t plane) const override {
     DCHECK_LT(plane, planes_.size());
-    return gbm_bo_get_plane_handle(bo_, plane).u32;
+    return gbm_bo_get_handle_for_plane(bo_, plane).u32;
   }
   uint32_t GetHandle() const override { return gbm_bo_get_handle(bo_).u32; }
   gfx::NativePixmapHandle ExportHandle() const override {
@@ -129,11 +174,18 @@ std::unique_ptr<Buffer> CreateBufferForBO(struct gbm_bo* bo,
   std::vector<base::ScopedFD> fds;
   std::vector<gfx::NativePixmapPlane> planes;
 
-  const uint64_t modifier = gbm_bo_get_format_modifier(bo);
-  for (size_t i = 0; i < gbm_bo_get_num_planes(bo); ++i) {
+  const uint64_t modifier = gbm_bo_get_modifier(bo);
+  const int plane_count = gbm_bo_get_plane_count(bo);
+  // The Mesa's gbm implementation explicitly checks whether plane count <= and
+  // returns 1 if the condition is true. Nevertheless, use a DCHECK here to make
+  // sure the condition is not broken there.
+  DCHECK_GT(plane_count, 0);
+  // Ensure there are no differences in integer signs by casting any possible
+  // values to size_t.
+  for (size_t i = 0; i < static_cast<size_t>(plane_count); ++i) {
     // The fd returned by gbm_bo_get_fd is not ref-counted and need to be
     // kept open for the lifetime of the buffer.
-    base::ScopedFD fd(gbm_bo_get_plane_fd(bo, i));
+    base::ScopedFD fd(GetPlaneFdForBo(bo, i));
 
     // TODO(dcastagna): support multiple fds.
     // crbug.com/642410
@@ -146,9 +198,9 @@ std::unique_ptr<Buffer> CreateBufferForBO(struct gbm_bo* bo,
       fds.emplace_back(std::move(fd));
     }
 
-    planes.emplace_back(gbm_bo_get_plane_stride(bo, i),
-                        gbm_bo_get_plane_offset(bo, i),
-                        gbm_bo_get_plane_size(bo, i), modifier);
+    planes.emplace_back(gbm_bo_get_stride_for_plane(bo, i),
+                        gbm_bo_get_offset(bo, i), GetSizeOfPlane(bo, i),
+                        modifier);
   }
   return std::make_unique<Buffer>(bo, format, flags, modifier, std::move(fds),
                                   size, std::move(planes));
@@ -193,23 +245,33 @@ class Device final : public ui::GbmDevice {
     DCHECK_EQ(planes[0].offset, 0);
 
     // Try to use scanout if supported.
-    int gbm_flags = GBM_BO_USE_SCANOUT | GBM_BO_USE_TEXTURING;
+    int gbm_flags = GBM_BO_USE_SCANOUT;
+#if defined(MINIGBM)
+    gbm_flags |= GBM_BO_USE_TEXTURING;
+#endif
     if (!gbm_device_is_format_supported(device_, format, gbm_flags))
       gbm_flags &= ~GBM_BO_USE_SCANOUT;
 
     struct gbm_bo* bo = nullptr;
     if (gbm_device_is_format_supported(device_, format, gbm_flags)) {
-      struct gbm_import_fd_planar_data fd_data;
+      struct gbm_import_fd_modifier_data fd_data;
       fd_data.width = size.width();
       fd_data.height = size.height();
       fd_data.format = format;
+      fd_data.modifier = DRM_FORMAT_MOD_NONE;
 
       DCHECK_LE(planes.size(), 3u);
       for (size_t i = 0; i < planes.size(); ++i) {
         fd_data.fds[i] = fds[i < fds.size() ? i : 0].get();
         fd_data.strides[i] = planes[i].stride;
         fd_data.offsets[i] = planes[i].offset;
-        fd_data.format_modifiers[i] = planes[i].modifier;
+        if (fd_data.modifier == DRM_FORMAT_MOD_NONE)
+          fd_data.modifier = planes[i].modifier;
+
+        if (fd_data.modifier != planes[i].modifier) {
+          LOG(ERROR) << "Format modifier must be the same for all the planes";
+          return nullptr;
+        }
       }
 
       // The fd passed to gbm_bo_import is not ref-counted and need to be

--- a/src/ui/ozone/common/stub_client_native_pixmap_factory.cc
+++ b/src/ui/ozone/common/stub_client_native_pixmap_factory.cc
@@ -15,10 +15,6 @@ class StubClientNativePixmapFactory : public gfx::ClientNativePixmapFactory {
   ~StubClientNativePixmapFactory() override {}
 
   // ClientNativePixmapFactory:
-  bool IsConfigurationSupported(gfx::BufferFormat format,
-                                gfx::BufferUsage usage) const override {
-    return false;
-  }
   std::unique_ptr<gfx::ClientNativePixmap> ImportFromHandle(
       const gfx::NativePixmapHandle& handle,
       const gfx::Size& size,

--- a/src/ui/ozone/platform/cast/client_native_pixmap_factory_cast.cc
+++ b/src/ui/ozone/platform/cast/client_native_pixmap_factory_cast.cc
@@ -36,12 +36,6 @@ class ClientNativePixmapCast : public gfx::ClientNativePixmap {
 class ClientNativePixmapFactoryCast : public gfx::ClientNativePixmapFactory {
  public:
   // ClientNativePixmapFactoryCast implementation:
-  bool IsConfigurationSupported(gfx::BufferFormat format,
-                                gfx::BufferUsage usage) const override {
-    return format == gfx::BufferFormat::BGRA_8888 &&
-           usage == gfx::BufferUsage::SCANOUT;
-  }
-
   std::unique_ptr<gfx::ClientNativePixmap> ImportFromHandle(
       const gfx::NativePixmapHandle& handle,
       const gfx::Size& size,

--- a/src/ui/ozone/platform/cast/ozone_platform_cast.cc
+++ b/src/ui/ozone/platform/cast/ozone_platform_cast.cc
@@ -109,6 +109,11 @@ class OzonePlatformCast : public OzonePlatform {
     // On Cast platform the display is initialized by low-level non-Ozone code.
     return nullptr;
   }
+  bool IsNativePixmapConfigSupported(gfx::BufferFormat format,
+                                     gfx::BufferUsage usage) const override {
+    return format == gfx::BufferFormat::BGRA_8888 &&
+           usage == gfx::BufferUsage::SCANOUT;
+  }
 
   void InitializeUI(const InitParams& params) override {
     device_manager_ = CreateDeviceManager();

--- a/src/ui/ozone/platform/drm/ozone_platform_gbm.cc
+++ b/src/ui/ozone/platform/drm/ozone_platform_gbm.cc
@@ -23,6 +23,7 @@
 #include "ui/events/ozone/device/device_manager.h"
 #include "ui/events/ozone/evdev/event_factory_evdev.h"
 #include "ui/events/ozone/layout/keyboard_layout_engine_manager.h"
+#include "ui/gfx/linux/client_native_pixmap_dmabuf.h"
 #include "ui/ozone/platform/drm/common/drm_util.h"
 #include "ui/ozone/platform/drm/gpu/drm_device_generator.h"
 #include "ui/ozone/platform/drm/gpu/drm_device_manager.h"
@@ -178,6 +179,12 @@ class OzonePlatformGbm : public OzonePlatform {
     return std::make_unique<DrmNativeDisplayDelegate>(display_manager_.get());
   }
 
+  bool IsNativePixmapConfigSupported(gfx::BufferFormat format,
+                                     gfx::BufferUsage usage) const override {
+    return gfx::ClientNativePixmapDmaBuf::IsConfigurationSupported(format,
+                                                                   usage);
+  }
+
   void InitializeUI(const InitParams& args) override {
     // Ozone drm can operate in four modes configured at
     // runtime. Three process modes:
@@ -191,12 +198,13 @@ class OzonePlatformGbm : public OzonePlatform {
     //
     // and 2 connection modes
     //   a. Viz is launched via content::GpuProcessHost and it notifies the
-    //   ozone host when Viz becomes available. b. The ozone host uses a service
-    //   manager to launch and connect to Viz.
+    //   ozone host when Viz becomes available. b. The ozone host uses a
+    //   service manager to launch and connect to Viz.
     //
     // Combinations 1a, 2b, and 3a, and 3b are supported and expected to work.
     // Combination 1a will hopefully be deprecated and replaced with 3a.
-    // Combination 2b adds undesirable code-debt and the intent is to remove it.
+    // Combination 2b adds undesirable code-debt and the intent is to remove
+    // it.
 
     single_process_ = args.single_process;
     using_mojo_ = args.using_mojo || args.connector != nullptr;
@@ -205,6 +213,7 @@ class OzonePlatformGbm : public OzonePlatform {
     device_manager_ = CreateDeviceManager();
     window_manager_.reset(new DrmWindowHostManager());
     cursor_.reset(new DrmCursor(window_manager_.get()));
+
 #if BUILDFLAG(USE_XKBCOMMON)
     KeyboardLayoutEngineManager::SetKeyboardLayoutEngine(
         std::make_unique<XkbKeyboardLayoutEngine>(xkb_evdev_code_converter_));

--- a/src/ui/ozone/platform/wayland/BUILD.gn
+++ b/src/ui/ozone/platform/wayland/BUILD.gn
@@ -94,6 +94,7 @@ source_set("wayland") {
     "//third_party/minigbm",
     "//third_party/wayland:wayland_client",
     "//third_party/wayland-protocols:linux_dmabuf_protocol",
+    "//third_party/wayland-protocols:presentation_time_protocol", 
     "//third_party/wayland-protocols:text_input_protocol",
     "//third_party/wayland-protocols:xdg_shell_protocol",
     "//ui/base",

--- a/src/ui/ozone/platform/wayland/BUILD.gn
+++ b/src/ui/ozone/platform/wayland/BUILD.gn
@@ -21,6 +21,8 @@ source_set("wayland") {
     "gpu/wayland_connection_proxy.h",
     "ozone_platform_wayland.cc",
     "ozone_platform_wayland.h",
+    "wayland_buffer_manager.cc",
+    "wayland_buffer_manager.h",
     "wayland_connection.cc",
     "wayland_connection.h",
     "wayland_connection_connector.cc",

--- a/src/ui/ozone/platform/wayland/BUILD.gn
+++ b/src/ui/ozone/platform/wayland/BUILD.gn
@@ -113,7 +113,7 @@ source_set("wayland") {
     "//ui/gfx/geometry",
     "//ui/ozone:ozone_base",
     "//ui/ozone/common",
-    "//ui/ozone/common/linux",
+    "//ui/ozone/common/linux:drm",
     "//ui/ozone/public/interfaces/wayland:wayland_interfaces",
     "//ui/platform_window",
     "//ui/platform_window/platform_window_handler",
@@ -138,7 +138,7 @@ source_set("wayland") {
       "//third_party/libdrm",
       "//third_party/minigbm",
       "//ui/gfx:memory_buffer",
-      "//ui/ozone/common/linux",
+      "//ui/ozone/common/linux:gbm",
     ]
   }
 

--- a/src/ui/ozone/platform/wayland/client_native_pixmap_factory_wayland.cc
+++ b/src/ui/ozone/platform/wayland/client_native_pixmap_factory_wayland.cc
@@ -25,12 +25,6 @@ class ClientNativePixmapFactoryWayland : public gfx::ClientNativePixmapFactory {
                                 gfx::BufferUsage usage) const override {
     OzonePlatform::PlatformProperties properties =
         OzonePlatform::GetInstance()->GetPlatformProperties();
-    if (properties.supported_buffer_formats.empty()) {
-      // If the compositor did not announce supported buffer formats, do our
-      // best and assume those are supported.
-      return dmabuf_factory_->IsConfigurationSupported(format, usage);
-    }
-
     for (auto buffer_format : properties.supported_buffer_formats) {
       if (buffer_format == format)
         return dmabuf_factory_->IsConfigurationSupported(format, usage);

--- a/src/ui/ozone/platform/wayland/client_native_pixmap_factory_wayland.cc
+++ b/src/ui/ozone/platform/wayland/client_native_pixmap_factory_wayland.cc
@@ -4,50 +4,15 @@
 
 #include "ui/ozone/platform/wayland/client_native_pixmap_factory_wayland.h"
 
-#include "ui/gfx/linux/client_native_pixmap_dmabuf.h"
 #include "ui/gfx/linux/client_native_pixmap_factory_dmabuf.h"
 #include "ui/ozone/common/stub_client_native_pixmap_factory.h"
 #include "ui/ozone/public/ozone_platform.h"
 
 namespace ui {
 
-// Implements ClientNativePixmapFactory to provide a more accurate buffer format
-// support when Wayland dmabuf is used.
-class ClientNativePixmapFactoryWayland : public gfx::ClientNativePixmapFactory {
- public:
-  ClientNativePixmapFactoryWayland() {
-    dmabuf_factory_.reset(gfx::CreateClientNativePixmapFactoryDmabuf(
-        true /* supports_native_pixmap_import_from_dmabuf */));
-  }
-  ~ClientNativePixmapFactoryWayland() override {}
-
-  // ClientNativePixmapFactory overrides:
-  bool IsConfigurationSupported(gfx::BufferFormat format,
-                                gfx::BufferUsage usage) const override {
-    OzonePlatform::PlatformProperties properties =
-        OzonePlatform::GetInstance()->GetPlatformProperties();
-    for (auto buffer_format : properties.supported_buffer_formats) {
-      if (buffer_format == format)
-        return dmabuf_factory_->IsConfigurationSupported(format, usage);
-    }
-    return false;
-  }
-
-  std::unique_ptr<gfx::ClientNativePixmap> ImportFromHandle(
-      const gfx::NativePixmapHandle& handle,
-      const gfx::Size& size,
-      gfx::BufferUsage usage) override {
-    return dmabuf_factory_->ImportFromHandle(handle, size, usage);
-  }
-
- private:
-  std::unique_ptr<ClientNativePixmapFactory> dmabuf_factory_;
-  DISALLOW_COPY_AND_ASSIGN(ClientNativePixmapFactoryWayland);
-};
-
 gfx::ClientNativePixmapFactory* CreateClientNativePixmapFactoryWayland() {
 #if defined(WAYLAND_GBM)
-  return new ClientNativePixmapFactoryWayland();
+  return gfx::CreateClientNativePixmapFactoryDmabuf();
 #else
   return CreateStubClientNativePixmapFactory();
 #endif

--- a/src/ui/ozone/platform/wayland/client_native_pixmap_factory_wayland.cc
+++ b/src/ui/ozone/platform/wayland/client_native_pixmap_factory_wayland.cc
@@ -6,6 +6,7 @@
 
 #include "ui/gfx/linux/client_native_pixmap_dmabuf.h"
 #include "ui/gfx/linux/client_native_pixmap_factory_dmabuf.h"
+#include "ui/ozone/common/stub_client_native_pixmap_factory.h"
 #include "ui/ozone/public/ozone_platform.h"
 
 namespace ui {
@@ -50,7 +51,11 @@ class ClientNativePixmapFactoryWayland : public gfx::ClientNativePixmapFactory {
 };
 
 gfx::ClientNativePixmapFactory* CreateClientNativePixmapFactoryWayland() {
+#if defined(WAYLAND_GBM)
   return new ClientNativePixmapFactoryWayland();
+#else
+  return CreateStubClientNativePixmapFactory();
+#endif
 }
 
 }  // namespace ui

--- a/src/ui/ozone/platform/wayland/client_native_pixmap_factory_wayland.cc
+++ b/src/ui/ozone/platform/wayland/client_native_pixmap_factory_wayland.cc
@@ -16,7 +16,8 @@ namespace ui {
 class ClientNativePixmapFactoryWayland : public gfx::ClientNativePixmapFactory {
  public:
   ClientNativePixmapFactoryWayland() {
-    dmabuf_factory_.reset(gfx::CreateClientNativePixmapFactoryDmabuf());
+    dmabuf_factory_.reset(gfx::CreateClientNativePixmapFactoryDmabuf(
+        true /* supports_native_pixmap_import_from_dmabuf */));
   }
   ~ClientNativePixmapFactoryWayland() override {}
 

--- a/src/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc
+++ b/src/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc
@@ -58,13 +58,7 @@ bool GbmPixmapWayland::InitializeBuffer(gfx::Size size,
       break;
     case gfx::BufferUsage::GPU_READ_CPU_READ_WRITE:
     case gfx::BufferUsage::GPU_READ_CPU_READ_WRITE_PERSISTENT:
-      // mmap cannot be used with gbm buffers on a different process. That is,
-      // Linux disallows this and "permission denied" is returned. To overcome
-      // this and make software rasterization working, buffers must be created
-      // on the browser process and gbm_bo_map must be used.
-      // TODO(msisov): add support fir these two buffer usage cases.
-      // https://crbug.com/864914
-      LOG(FATAL) << "This scenario is not supported in Wayland now";
+      flags = GBM_BO_USE_LINEAR;
       break;
     default:
       NOTREACHED() << "Not supported buffer format";

--- a/src/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc
+++ b/src/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc
@@ -78,7 +78,7 @@ bool GbmPixmapWayland::InitializeBuffer(gfx::Size size,
 
 void* /* EGLClientBuffer */ GbmPixmapWayland::GetEGLClientBuffer() const {
   //TODO(msisov): check if this is required. In the upstream case, there is no such an API.
-  NOTIMPLEMENTED();
+  NOTIMPLEMENTED_LOG_ONCE();
   return nullptr;
 }
 

--- a/src/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc
+++ b/src/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc
@@ -109,11 +109,7 @@ int GbmPixmapWayland::GetDmaBufOffset(size_t plane) const {
 }
 
 uint64_t GbmPixmapWayland::GetDmaBufModifier(size_t plane) const {
-  // TODO(msisov): figure out why returning format modifier results in
-  // EGL_BAD_ALLOC.
-  //
-  // return gbm_bo_->get_format_modifier();
-  return 0;
+  return gbm_bo_->GetFormatModifier();
 }
 
 gfx::BufferFormat GbmPixmapWayland::GetBufferFormat() const {

--- a/src/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.cc
+++ b/src/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.cc
@@ -220,12 +220,11 @@ void GbmSurfacelessWayland::FenceRetired(PendingFrame* frame) {
   SubmitFrame();
 }
 
-void GbmSurfacelessWayland::OnScheduleBufferSwapDone(gfx::SwapResult result) {
+void GbmSurfacelessWayland::OnScheduleBufferSwapDone(
+    gfx::SwapResult result,
+    const gfx::PresentationFeedback& feedback) {
   OnSubmission(result, nullptr);
-  // TODO: presentation.
-  OnPresentation(
-      gfx::PresentationFeedback(base::TimeTicks::Now(), base::TimeDelta(),
-                                gfx::PresentationFeedback::kZeroCopy));
+  OnPresentation(feedback);
   planes_.clear();
 }
 

--- a/src/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.cc
+++ b/src/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.cc
@@ -69,8 +69,7 @@ bool GbmSurfacelessWayland::SupportsAsyncSwap() {
 }
 
 bool GbmSurfacelessWayland::SupportsPostSubBuffer() {
-  // TODO(msisov): figure out how to enable subbuffers with wayland/dmabuf.
-  return false;
+  return true;
 }
 
 gfx::SwapResult GbmSurfacelessWayland::PostSubBuffer(
@@ -135,8 +134,10 @@ void GbmSurfacelessWayland::PostSubBufferAsync(
     int height,
     const SwapCompletionCallback& completion_callback,
     const PresentationCallback& presentation_callback) {
-  // See the comment in SupportsPostSubBuffer.
-  NOTREACHED();
+  PendingFrame* frame = unsubmitted_frames_.back().get();
+  frame->damage_region_ = gfx::Rect(x, y, width, height);
+
+  SwapBuffersAsync(completion_callback, presentation_callback);
 }
 
 EGLConfig GbmSurfacelessWayland::GetConfig() {
@@ -203,6 +204,7 @@ void GbmSurfacelessWayland::SubmitFrame() {
                        weak_factory_.GetWeakPtr());
     uint32_t buffer_id = planes_.back().pixmap->GetUniqueId();
     surface_factory_->ScheduleBufferSwap(widget_, buffer_id,
+                                         submitted_frame_->damage_region_,
                                          std::move(callback));
   }
 }

--- a/src/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.cc
+++ b/src/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.cc
@@ -59,8 +59,6 @@ bool GbmSurfacelessWayland::IsOffscreen() {
 }
 
 bool GbmSurfacelessWayland::SupportsPresentationCallback() {
-  // TODO(msisov): enable a real presentation callback for wayland. For now, we
-  // just blindly say it was successful. https://crbug.com/859012.
   return true;
 }
 

--- a/src/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.h
+++ b/src/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.h
@@ -78,7 +78,8 @@ class GbmSurfacelessWayland : public gl::SurfacelessEGL {
   EGLSyncKHR InsertFence(bool implicit);
   void FenceRetired(PendingFrame* frame);
 
-  void OnScheduleBufferSwapDone(gfx::SwapResult result);
+  void OnScheduleBufferSwapDone(gfx::SwapResult result,
+                                const gfx::PresentationFeedback& feedback);
   void OnSubmission(gfx::SwapResult result,
                     std::unique_ptr<gfx::GpuFence> out_fence);
   void OnPresentation(const gfx::PresentationFeedback& feedback);

--- a/src/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.h
+++ b/src/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.h
@@ -78,6 +78,7 @@ class GbmSurfacelessWayland : public gl::SurfacelessEGL {
   EGLSyncKHR InsertFence(bool implicit);
   void FenceRetired(PendingFrame* frame);
 
+  void OnScheduleBufferSwapDone(gfx::SwapResult result);
   void OnSubmission(gfx::SwapResult result,
                     std::unique_ptr<gfx::GpuFence> out_fence);
   void OnPresentation(const gfx::PresentationFeedback& feedback);

--- a/src/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.h
+++ b/src/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.h
@@ -68,6 +68,10 @@ class GbmSurfacelessWayland : public gl::SurfacelessEGL {
 
     bool ready = false;
     gfx::SwapResult swap_result = gfx::SwapResult::SWAP_FAILED;
+    // A region of the updated content in a corresponding frame. It's used to
+    // advice Wayland which part of a buffer is going to be updated. Passing {0,
+    // 0, 0, 0} results in a whole buffer update on the Wayland compositor side.
+    gfx::Rect damage_region_ = gfx::Rect();
     std::vector<gl::GLSurfaceOverlay> overlays;
     SwapCompletionCallback completion_callback;
     PresentationCallback presentation_callback;

--- a/src/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc
+++ b/src/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc
@@ -86,11 +86,13 @@ void WaylandConnectionProxy::DestroyZwpLinuxDmabufInternal(uint32_t buffer_id) {
   wc_ptr_->DestroyZwpLinuxDmabuf(buffer_id);
 }
 
-void WaylandConnectionProxy::ScheduleBufferSwap(gfx::AcceleratedWidget widget,
-                                                uint32_t buffer_id) {
+void WaylandConnectionProxy::ScheduleBufferSwap(
+    gfx::AcceleratedWidget widget,
+    uint32_t buffer_id,
+    wl::BufferSwapCallback callback) {
   DCHECK(gpu_thread_runner_->BelongsToCurrentThread());
   DCHECK(wc_ptr_);
-  wc_ptr_->ScheduleBufferSwap(widget, buffer_id);
+  wc_ptr_->ScheduleBufferSwap(widget, buffer_id, std::move(callback));
 }
 
 WaylandWindow* WaylandConnectionProxy::GetWindow(

--- a/src/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc
+++ b/src/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc
@@ -89,10 +89,12 @@ void WaylandConnectionProxy::DestroyZwpLinuxDmabufInternal(uint32_t buffer_id) {
 void WaylandConnectionProxy::ScheduleBufferSwap(
     gfx::AcceleratedWidget widget,
     uint32_t buffer_id,
+    const gfx::Rect& damage_region,
     wl::BufferSwapCallback callback) {
   DCHECK(gpu_thread_runner_->BelongsToCurrentThread());
   DCHECK(wc_ptr_);
-  wc_ptr_->ScheduleBufferSwap(widget, buffer_id, std::move(callback));
+  wc_ptr_->ScheduleBufferSwap(widget, buffer_id, damage_region,
+                              std::move(callback));
 }
 
 WaylandWindow* WaylandConnectionProxy::GetWindow(

--- a/src/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h
+++ b/src/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h
@@ -11,6 +11,7 @@
 #include "mojo/public/cpp/bindings/binding_set.h"
 #include "ui/gfx/native_widget_types.h"
 #include "ui/ozone/platform/wayland/wayland_connection.h"
+#include "ui/ozone/platform/wayland/wayland_util.h"
 #include "ui/ozone/public/interfaces/wayland/wayland_connection.mojom.h"
 
 #if defined(WAYLAND_GBM)
@@ -18,6 +19,10 @@
 #endif
 
 struct wl_shm;
+
+namespace gfx {
+enum class SwapResult;
+}
 
 namespace ui {
 
@@ -58,7 +63,11 @@ class WaylandConnectionProxy : public ozone::mojom::WaylandConnectionClient {
 
   // Asks Wayland to find a wl_buffer with the |buffer_id| and schedule a
   // buffer swap for a WaylandWindow, which backs the following |widget|.
-  void ScheduleBufferSwap(gfx::AcceleratedWidget widget, uint32_t buffer_id);
+  // The |callback| is called once a frame callback from the Wayland server
+  // is received.
+  void ScheduleBufferSwap(gfx::AcceleratedWidget widget,
+                          uint32_t buffer_id,
+                          wl::BufferSwapCallback callback);
 
 #if defined(WAYLAND_GBM)
   // Returns a gbm_device based on a DRM render node.

--- a/src/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h
+++ b/src/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h
@@ -15,7 +15,7 @@
 #include "ui/ozone/public/interfaces/wayland/wayland_connection.mojom.h"
 
 #if defined(WAYLAND_GBM)
-#include "ui/ozone/common/linux/gbm_device.h"
+#include "ui/ozone/common/linux/gbm_device.h"  // nogncheck
 #endif
 
 struct wl_shm;

--- a/src/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h
+++ b/src/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h
@@ -22,7 +22,8 @@ struct wl_shm;
 
 namespace gfx {
 enum class SwapResult;
-}
+class Rect;
+}  // namespace gfx
 
 namespace ui {
 
@@ -67,6 +68,7 @@ class WaylandConnectionProxy : public ozone::mojom::WaylandConnectionClient {
   // is received.
   void ScheduleBufferSwap(gfx::AcceleratedWidget widget,
                           uint32_t buffer_id,
+                          const gfx::Rect& damage_region,
                           wl::BufferSwapCallback callback);
 
 #if defined(WAYLAND_GBM)

--- a/src/ui/ozone/platform/wayland/ozone_platform_wayland.cc
+++ b/src/ui/ozone/platform/wayland/ozone_platform_wayland.cc
@@ -51,6 +51,10 @@ class OzonePlatformWayland : public OzonePlatform {
     // https://github.com/wayland-project/wayland-protocols/commit/76d1ae8c65739eff3434ef219c58a913ad34e988
     properties_.custom_frame_pref_default = true;
     properties_.use_system_title_bar = false;
+    // Ozone/Wayland relies on the mojo communication when running in
+    // !single_process.
+    // TODO(msisov, rjkroege): Remove after http://crbug.com/806092.
+    properties_.requires_mojo = true;
   }
   ~OzonePlatformWayland() override {}
 
@@ -164,8 +168,7 @@ class OzonePlatformWayland : public OzonePlatform {
   }
 
   const PlatformProperties& GetPlatformProperties() override {
-    DCHECK(connection_.get());
-    if (properties_.supported_buffer_formats.empty()) {
+    if (connection_ && properties_.supported_buffer_formats.empty()) {
       properties_.supported_buffer_formats =
           connection_->GetSupportedBufferFormats();
     }

--- a/src/ui/ozone/platform/wayland/ozone_platform_wayland.cc
+++ b/src/ui/ozone/platform/wayland/ozone_platform_wayland.cc
@@ -10,6 +10,7 @@
 #include "ui/display/manager/fake_display_delegate.h"
 #include "ui/events/ozone/layout/keyboard_layout_engine_manager.h"
 #include "ui/events/system_input_injector.h"
+#include "ui/gfx/linux/client_native_pixmap_dmabuf.h"
 #include "ui/ozone/common/stub_overlay_manager.h"
 #include "ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h"
 #include "ui/ozone/platform/wayland/wayland_connection.h"
@@ -41,21 +42,25 @@ namespace ui {
 
 namespace {
 
-class OzonePlatformWayland : public OzonePlatform {
- public:
-  OzonePlatformWayland() {
+constexpr OzonePlatform::PlatformProperties kWaylandPlatformProperties = {
+    /*needs_view_token=*/false,
+
     // Supporting server-side decorations requires a support of xdg-decorations.
     // But this protocol has been accepted into the upstream recently, and it
     // will take time before it is taken by compositors. For now, always use
     // custom frames and disallow switching to server-side frames.
     // https://github.com/wayland-project/wayland-protocols/commit/76d1ae8c65739eff3434ef219c58a913ad34e988
-    properties_.custom_frame_pref_default = true;
-    properties_.use_system_title_bar = false;
+    /*custom_frame_pref_default=*/true,
+    /*use_system_title_bar=*/false,
+
     // Ozone/Wayland relies on the mojo communication when running in
     // !single_process.
     // TODO(msisov, rjkroege): Remove after http://crbug.com/806092.
-    properties_.requires_mojo = true;
-  }
+    /*requires_mojo=*/true};
+
+class OzonePlatformWayland : public OzonePlatform {
+ public:
+  OzonePlatformWayland() {}
   ~OzonePlatformWayland() override {}
 
   // OzonePlatform
@@ -117,6 +122,18 @@ class OzonePlatformWayland : public OzonePlatform {
     return connection_->wayland_output_manager()->CreateWaylandScreen();
   }
 
+  bool IsNativePixmapConfigSupported(gfx::BufferFormat format,
+                                     gfx::BufferUsage usage) const override {
+    if (std::find(supported_buffer_formats_.begin(),
+                  supported_buffer_formats_.end(),
+                  format) == supported_buffer_formats_.end()) {
+      return false;
+    }
+
+    return gfx::ClientNativePixmapDmaBuf::IsConfigurationSupported(format,
+                                                                   usage);
+  }
+
   void InitializeUI(const InitParams& args) override {
 #if BUILDFLAG(USE_XKBCOMMON)
     KeyboardLayoutEngineManager::SetKeyboardLayoutEngine(
@@ -139,6 +156,7 @@ class OzonePlatformWayland : public OzonePlatform {
     overlay_manager_.reset(new StubOverlayManager);
     input_controller_ = CreateStubInputController();
     gpu_platform_support_host_.reset(CreateStubGpuPlatformSupportHost());
+    supported_buffer_formats_ = connection_->GetSupportedBufferFormats();
   }
 
   void InitializeGPU(const InitParams& args) override {
@@ -168,11 +186,7 @@ class OzonePlatformWayland : public OzonePlatform {
   }
 
   const PlatformProperties& GetPlatformProperties() override {
-    if (connection_ && properties_.supported_buffer_formats.empty()) {
-      properties_.supported_buffer_formats =
-          connection_->GetSupportedBufferFormats();
-    }
-    return properties_;
+    return kWaylandPlatformProperties;
   }
 
   void AddInterfaces(
@@ -208,7 +222,7 @@ class OzonePlatformWayland : public OzonePlatform {
   std::unique_ptr<WaylandConnectionProxy> proxy_;
   std::unique_ptr<WaylandConnectionConnector> connector_;
 
-  PlatformProperties properties_;
+  std::vector<gfx::BufferFormat> supported_buffer_formats_;
 
   DISALLOW_COPY_AND_ASSIGN(OzonePlatformWayland);
 };

--- a/src/ui/ozone/platform/wayland/wayland_buffer_manager.cc
+++ b/src/ui/ozone/platform/wayland/wayland_buffer_manager.cc
@@ -1,0 +1,282 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ui/ozone/platform/wayland/wayland_buffer_manager.h"
+
+#include <drm_fourcc.h>
+
+#include <linux-dmabuf-unstable-v1-client-protocol.h>
+
+#include "base/trace_event/trace_event.h"
+#include "ui/ozone/common/linux/drm_util_linux.h"
+#include "ui/ozone/platform/wayland/wayland_connection.h"
+#include "ui/ozone/platform/wayland/wayland_window.h"
+
+namespace ui {
+
+WaylandBufferManager::WaylandBufferManager(
+    zwp_linux_dmabuf_v1* zwp_linux_dmabuf,
+    WaylandConnection* connection)
+    : zwp_linux_dmabuf_(zwp_linux_dmabuf), connection_(connection) {
+  static const zwp_linux_dmabuf_v1_listener dmabuf_listener = {
+      &WaylandBufferManager::Format, &WaylandBufferManager::Modifiers,
+  };
+  zwp_linux_dmabuf_v1_add_listener(zwp_linux_dmabuf_.get(), &dmabuf_listener,
+                                   this);
+
+  // A roundtrip after binding guarantees that the client has received all
+  // supported formats.
+  wl_display_roundtrip(connection->display());
+}
+
+WaylandBufferManager::~WaylandBufferManager() {
+  DCHECK(pending_buffer_map_.empty() && params_to_id_map_.empty() &&
+         buffers_.empty());
+}
+
+bool WaylandBufferManager::CreateBuffer(base::File file,
+                                        uint32_t width,
+                                        uint32_t height,
+                                        const std::vector<uint32_t>& strides,
+                                        const std::vector<uint32_t>& offsets,
+                                        uint32_t format,
+                                        const std::vector<uint64_t>& modifiers,
+                                        uint32_t planes_count,
+                                        uint32_t buffer_id) {
+  TRACE_EVENT2("Wayland", "WaylandBufferManager::CreateZwpLinuxDmabuf",
+               "Format", format, "Buffer id", buffer_id);
+
+  static const struct zwp_linux_buffer_params_v1_listener params_listener = {
+      WaylandBufferManager::CreateSucceeded,
+      WaylandBufferManager::CreateFailed};
+  if (!ValidateDataFromGpu(file, width, height, strides, offsets, format,
+                           modifiers, planes_count, buffer_id)) {
+    // base::File::Close() has an assertion that checks if blocking operations
+    // are allowed. Thus, manually close the fd here.
+    base::ScopedFD fd(file.TakePlatformFile());
+    fd.reset();
+    return false;
+  }
+
+  // Store |params| connected to |buffer_id| to track buffer creation and
+  // identify, which buffer a client wants to use.
+  DCHECK(zwp_linux_dmabuf_);
+  struct zwp_linux_buffer_params_v1* params =
+      zwp_linux_dmabuf_v1_create_params(zwp_linux_dmabuf_.get());
+  params_to_id_map_.insert(
+      std::pair<struct zwp_linux_buffer_params_v1*, uint32_t>(params,
+                                                              buffer_id));
+  uint32_t fd = file.TakePlatformFile();
+  for (size_t i = 0; i < planes_count; i++) {
+    zwp_linux_buffer_params_v1_add(params, fd, i /* plane id */, offsets[i],
+                                   strides[i], 0 /* modifier hi */,
+                                   0 /* modifier lo */);
+  }
+  zwp_linux_buffer_params_v1_add_listener(params, &params_listener, this);
+  zwp_linux_buffer_params_v1_create(params, width, height, format, 0);
+
+  connection_->ScheduleFlush();
+  return true;
+}
+
+// TODO(msisov): handle buffer swap failure or success.
+bool WaylandBufferManager::SwapBuffer(gfx::AcceleratedWidget widget,
+                                      uint32_t buffer_id) {
+  TRACE_EVENT1("Wayland", "WaylandBufferManager::SwapBuffer", "Buffer id",
+               buffer_id);
+
+  if (!ValidateDataFromGpu(widget, buffer_id))
+    return false;
+
+  auto it = buffers_.find(buffer_id);
+  // A buffer might not exist by this time. So, store the request and process
+  // it once it is created.
+  if (it == buffers_.end()) {
+    auto pending_buffers_it = pending_buffer_map_.find(buffer_id);
+    if (pending_buffers_it != pending_buffer_map_.end()) {
+      // If a buffer didn't exist and second call for a swap comes, buffer must
+      // be associated with the same widget.
+      DCHECK_EQ(pending_buffers_it->second, widget);
+    } else {
+      pending_buffer_map_.insert(
+          std::pair<uint32_t, gfx::AcceleratedWidget>(buffer_id, widget));
+    }
+    return true;
+  }
+  struct wl_buffer* buffer = it->second.get();
+
+  WaylandWindow* window = connection_->GetWindow(widget);
+  if (!window) {
+    error_message_ = "A WaylandWindow with current widget does not exist";
+    return false;
+  }
+
+  // TODO(msisov): it would be beneficial to use real damage regions to improve
+  // performance.
+  //
+  // TODO(msisov): also start using wl_surface_frame callbacks for better
+  // performance.
+  wl_surface_damage(window->surface(), 0, 0, window->GetBounds().width(),
+                    window->GetBounds().height());
+  wl_surface_attach(window->surface(), buffer, 0, 0);
+  wl_surface_commit(window->surface());
+
+  connection_->ScheduleFlush();
+  return true;
+}
+
+bool WaylandBufferManager::DestroyBuffer(uint32_t buffer_id) {
+  TRACE_EVENT1("Wayland", "WaylandBufferManager::DestroyZwpLinuxDmabuf",
+               "Buffer id", buffer_id);
+
+  auto it = buffers_.find(buffer_id);
+  if (it == buffers_.end()) {
+    error_message_ = "Trying to destroy non-existing buffer";
+    return false;
+  }
+  buffers_.erase(it);
+
+  connection_->ScheduleFlush();
+  return true;
+}
+
+void WaylandBufferManager::ClearState() {
+  buffers_.clear();
+  params_to_id_map_.clear();
+  pending_buffer_map_.clear();
+}
+
+bool WaylandBufferManager::ValidateDataFromGpu(
+    const base::File& file,
+    uint32_t width,
+    uint32_t height,
+    const std::vector<uint32_t>& strides,
+    const std::vector<uint32_t>& offsets,
+    uint32_t format,
+    const std::vector<uint64_t>& modifiers,
+    uint32_t planes_count,
+    uint32_t buffer_id) {
+  std::string reason;
+  if (!file.IsValid())
+    reason = "Buffer fd is invalid";
+
+  if (width == 0 || height == 0)
+    reason = "Buffer size is invalid";
+
+  if (planes_count < 1)
+    reason = "Planes count cannot be less than 1";
+
+  if (planes_count != strides.size() || planes_count != offsets.size() ||
+      planes_count != modifiers.size()) {
+    reason = "Number of strides(" + std::to_string(strides.size()) +
+             ")/offsets(" + std::to_string(offsets.size()) + ")/modifiers(" +
+             std::to_string(modifiers.size()) +
+             ") does not correspond to the number of planes(" +
+             std::to_string(planes_count) + ")";
+  }
+
+  for (auto stride : strides) {
+    if (stride == 0)
+      reason = "Strides are invalid";
+  }
+
+  if (!IsValidBufferFormat(format))
+    reason = "Buffer format is invalid";
+
+  if (buffer_id < 1)
+    reason = "Invalid buffer id: " + std::to_string(buffer_id);
+
+  if (!reason.empty()) {
+    error_message_ = std::move(reason);
+    return false;
+  }
+  return true;
+}
+
+bool WaylandBufferManager::ValidateDataFromGpu(
+    const gfx::AcceleratedWidget& widget,
+    uint32_t buffer_id) {
+  std::string reason;
+
+  if (widget == gfx::kNullAcceleratedWidget)
+    reason = "Invalid accelerated widget";
+
+  if (buffer_id < 1)
+    reason = "Invalid buffer id: " + std::to_string(buffer_id);
+
+  if (!reason.empty()) {
+    error_message_ = std::move(reason);
+    return false;
+  }
+
+  return true;
+}
+
+void WaylandBufferManager::CreateSucceededInternal(
+    struct zwp_linux_buffer_params_v1* params,
+    struct wl_buffer* new_buffer) {
+  // Find which buffer id |params| belong to and store wl_buffer
+  // with that id.
+  auto it = params_to_id_map_.find(params);
+  CHECK(it != params_to_id_map_.end());
+  uint32_t buffer_id = it->second;
+  params_to_id_map_.erase(params);
+  zwp_linux_buffer_params_v1_destroy(params);
+
+  buffers_.insert(std::pair<uint32_t, wl::Object<wl_buffer>>(
+      buffer_id, wl::Object<wl_buffer>(new_buffer)));
+
+  TRACE_EVENT1("Wayland", "WaylandBufferManager::CreateSucceeded", "Buffer id",
+               buffer_id);
+
+  auto pending_buffers_it = pending_buffer_map_.find(buffer_id);
+  if (pending_buffers_it != pending_buffer_map_.end()) {
+    gfx::AcceleratedWidget widget = pending_buffers_it->second;
+    pending_buffer_map_.erase(pending_buffers_it);
+    SwapBuffer(widget, buffer_id);
+  }
+}
+
+// static
+void WaylandBufferManager::Modifiers(
+    void* data,
+    struct zwp_linux_dmabuf_v1* zwp_linux_dmabuf,
+    uint32_t format,
+    uint32_t modifier_hi,
+    uint32_t modifier_lo) {
+  NOTIMPLEMENTED();
+}
+
+// static
+void WaylandBufferManager::Format(void* data,
+                                  struct zwp_linux_dmabuf_v1* zwp_linux_dmabuf,
+                                  uint32_t format) {
+  WaylandBufferManager* self = static_cast<WaylandBufferManager*>(data);
+  // Return on not the supported ARGB format.
+  if (format == DRM_FORMAT_ARGB2101010)
+    return;
+  self->supported_buffer_formats_.push_back(
+      GetBufferFormatFromFourCCFormat(format));
+}
+
+// static
+void WaylandBufferManager::CreateSucceeded(
+    void* data,
+    struct zwp_linux_buffer_params_v1* params,
+    struct wl_buffer* new_buffer) {
+  WaylandBufferManager* self = static_cast<WaylandBufferManager*>(data);
+
+  DCHECK(self);
+  self->CreateSucceededInternal(params, new_buffer);
+}
+
+// static
+void WaylandBufferManager::CreateFailed(
+    void* data,
+    struct zwp_linux_buffer_params_v1* params) {
+  zwp_linux_buffer_params_v1_destroy(params);
+  LOG(FATAL) << "zwp_linux_buffer_params.create failed";
+}
+
+}  // namespace ui

--- a/src/ui/ozone/platform/wayland/wayland_buffer_manager.cc
+++ b/src/ui/ozone/platform/wayland/wayland_buffer_manager.cc
@@ -104,8 +104,8 @@ bool WaylandBufferManager::CreateBuffer(base::File file,
   uint32_t fd = file.TakePlatformFile();
   for (size_t i = 0; i < planes_count; i++) {
     zwp_linux_buffer_params_v1_add(params, fd, i /* plane id */, offsets[i],
-                                   strides[i], 0 /* modifier hi */,
-                                   0 /* modifier lo */);
+                                   strides[i], modifiers[i] >> 32,
+                                   modifiers[i] & UINT32_MAX);
   }
   zwp_linux_buffer_params_v1_add_listener(params, &params_listener, this);
   zwp_linux_buffer_params_v1_create(params, width, height, format, 0);

--- a/src/ui/ozone/platform/wayland/wayland_buffer_manager.cc
+++ b/src/ui/ozone/platform/wayland/wayland_buffer_manager.cc
@@ -328,6 +328,21 @@ void WaylandBufferManager::OnBufferSwapped(Buffer* buffer) {
       .Run(buffer->swap_result, std::move(buffer->feedback));
 }
 
+void WaylandBufferManager::AddSupportedFourCCFormat(uint32_t fourcc_format) {
+  // Return on not the supported fourcc format.
+  if (!IsValidBufferFormat(fourcc_format))
+    return;
+
+  // It can happen that ::Format or ::Modifiers call can have already added such
+  // a format. Thus, we can ignore that format.
+  gfx::BufferFormat format = GetBufferFormatFromFourCCFormat(fourcc_format);
+  auto it = std::find(supported_buffer_formats_.begin(),
+                      supported_buffer_formats_.end(), format);
+  if (it != supported_buffer_formats_.end())
+    return;
+  supported_buffer_formats_.push_back(format);
+}
+
 // static
 void WaylandBufferManager::Modifiers(
     void* data,
@@ -335,7 +350,9 @@ void WaylandBufferManager::Modifiers(
     uint32_t format,
     uint32_t modifier_hi,
     uint32_t modifier_lo) {
-  NOTIMPLEMENTED();
+  WaylandBufferManager* self = static_cast<WaylandBufferManager*>(data);
+  if (self)
+    self->AddSupportedFourCCFormat(format);
 }
 
 // static
@@ -343,11 +360,8 @@ void WaylandBufferManager::Format(void* data,
                                   struct zwp_linux_dmabuf_v1* zwp_linux_dmabuf,
                                   uint32_t format) {
   WaylandBufferManager* self = static_cast<WaylandBufferManager*>(data);
-  // Return on not the supported ARGB format.
-  if (format == DRM_FORMAT_ARGB2101010)
-    return;
-  self->supported_buffer_formats_.push_back(
-      GetBufferFormatFromFourCCFormat(format));
+  if (self)
+    self->AddSupportedFourCCFormat(format);
 }
 
 // static

--- a/src/ui/ozone/platform/wayland/wayland_buffer_manager.cc
+++ b/src/ui/ozone/platform/wayland/wayland_buffer_manager.cc
@@ -313,7 +313,11 @@ void WaylandBufferManager::CreateSucceededInternal(
     }
   }
 
-  DCHECK(buffer);
+  // It can happen that buffer was destroyed by a client while the Wayland
+  // compositor was processing a request to create a wl_buffer.
+  if (!buffer)
+    return;
+
   buffer->wl_buffer.reset(new_buffer);
   buffer->params = nullptr;
   zwp_linux_buffer_params_v1_destroy(params);
@@ -370,7 +374,6 @@ void WaylandBufferManager::CreateSucceeded(
     struct zwp_linux_buffer_params_v1* params,
     struct wl_buffer* new_buffer) {
   WaylandBufferManager* self = static_cast<WaylandBufferManager*>(data);
-
   DCHECK(self);
   self->CreateSucceededInternal(params, new_buffer);
 }

--- a/src/ui/ozone/platform/wayland/wayland_buffer_manager.cc
+++ b/src/ui/ozone/platform/wayland/wayland_buffer_manager.cc
@@ -5,8 +5,8 @@
 #include "ui/ozone/platform/wayland/wayland_buffer_manager.h"
 
 #include <drm_fourcc.h>
-
 #include <linux-dmabuf-unstable-v1-client-protocol.h>
+#include <presentation-time-client-protocol.h>
 
 #include "base/trace_event/trace_event.h"
 #include "ui/ozone/common/linux/drm_util_linux.h"
@@ -14,6 +14,33 @@
 #include "ui/ozone/platform/wayland/wayland_window.h"
 
 namespace ui {
+
+namespace {
+
+uint32_t GetPresentationKindFlags(uint32_t flags) {
+  uint32_t presentation_flags = 0;
+  if (flags & WP_PRESENTATION_FEEDBACK_KIND_VSYNC)
+    presentation_flags |= gfx::PresentationFeedback::kVSync;
+  if (flags & WP_PRESENTATION_FEEDBACK_KIND_HW_CLOCK)
+    presentation_flags |= gfx::PresentationFeedback::kHWClock;
+  if (flags & WP_PRESENTATION_FEEDBACK_KIND_HW_COMPLETION)
+    presentation_flags |= gfx::PresentationFeedback::kHWCompletion;
+  if (flags & WP_PRESENTATION_FEEDBACK_KIND_ZERO_COPY)
+    presentation_flags |= gfx::PresentationFeedback::kZeroCopy;
+
+  return presentation_flags;
+}
+
+base::TimeTicks GetPresentationFeedbackTimeStamp(uint32_t tv_sec_hi,
+                                                 uint32_t tv_sec_lo,
+                                                 uint32_t tv_nsec) {
+  const int64_t seconds = (static_cast<int64_t>(tv_sec_hi) << 32) + tv_sec_lo;
+  const int64_t microseconds = seconds * base::Time::kMicrosecondsPerSecond +
+                               tv_nsec / base::Time::kNanosecondsPerMicrosecond;
+  return base::TimeTicks() + base::TimeDelta::FromMicroseconds(microseconds);
+}
+
+}  // namespace
 
 WaylandBufferManager::Buffer::Buffer() = default;
 WaylandBufferManager::Buffer::Buffer(uint32_t id,
@@ -132,8 +159,12 @@ bool WaylandBufferManager::DestroyBuffer(uint32_t buffer_id) {
   // It can happen that a buffer is destroyed before a frame callback comes.
   // Thus, just mark this as a successful swap, which is ok to do.
   Buffer* buffer = it->second.get();
-  if (!buffer->buffer_swap_callback.is_null())
-    std::move(buffer->buffer_swap_callback).Run(gfx::SwapResult::SWAP_ACK);
+  if (!buffer->buffer_swap_callback.is_null()) {
+    std::move(buffer->buffer_swap_callback)
+        .Run(gfx::SwapResult::SWAP_ACK,
+             gfx::PresentationFeedback(base::TimeTicks::Now(),
+                                       base::TimeDelta(), 0));
+  }
   buffers_.erase(it);
 
   connection_->ScheduleFlush();
@@ -167,6 +198,19 @@ bool WaylandBufferManager::SwapBuffer(Buffer* buffer) {
   buffer->wl_frame_callback.reset(wl_surface_frame(window->surface()));
   wl_callback_add_listener(buffer->wl_frame_callback.get(), &frame_listener,
                            this);
+
+  // Set up presentation feedback.
+  static const wp_presentation_feedback_listener feedback_listener = {
+      WaylandBufferManager::FeedbackSyncOutput,
+      WaylandBufferManager::FeedbackPresented,
+      WaylandBufferManager::FeedbackDiscarded};
+  if (connection_->presentation()) {
+    DCHECK(!buffer->wp_presentation_feedback);
+    buffer->wp_presentation_feedback.reset(wp_presentation_feedback(
+        connection_->presentation(), window->surface()));
+    wp_presentation_feedback_add_listener(
+        buffer->wp_presentation_feedback.get(), &feedback_listener, this);
+  }
 
   wl_surface_commit(window->surface());
 
@@ -268,6 +312,12 @@ void WaylandBufferManager::CreateSucceededInternal(
     SwapBuffer(buffer);
 }
 
+void WaylandBufferManager::OnBufferSwapped(Buffer* buffer) {
+  DCHECK(!buffer->buffer_swap_callback.is_null());
+  std::move(buffer->buffer_swap_callback)
+      .Run(buffer->swap_result, std::move(buffer->feedback));
+}
+
 // static
 void WaylandBufferManager::Modifiers(
     void* data,
@@ -318,8 +368,81 @@ void WaylandBufferManager::FrameCallbackDone(void* data,
   for (auto& item : self->buffers_) {
     Buffer* buffer = item.second.get();
     if (buffer->wl_frame_callback.get() == callback) {
-      std::move(buffer->buffer_swap_callback).Run(gfx::SwapResult::SWAP_ACK);
+      buffer->swap_result = gfx::SwapResult::SWAP_ACK;
       buffer->wl_frame_callback.reset();
+
+      // If presentation feedback is not supported, use fake feedback and
+      // trigger the callback.
+      if (!self->connection_->presentation()) {
+        buffer->feedback = gfx::PresentationFeedback(base::TimeTicks::Now(),
+                                                     base::TimeDelta(), 0);
+        self->OnBufferSwapped(buffer);
+      }
+      return;
+    }
+  }
+
+  NOTREACHED();
+}
+
+// static
+void WaylandBufferManager::FeedbackSyncOutput(
+    void* data,
+    struct wp_presentation_feedback* wp_presentation_feedback,
+    struct wl_output* output) {
+  NOTIMPLEMENTED_LOG_ONCE();
+}
+
+// static
+void WaylandBufferManager::FeedbackPresented(
+    void* data,
+    struct wp_presentation_feedback* wp_presentation_feedback,
+    uint32_t tv_sec_hi,
+    uint32_t tv_sec_lo,
+    uint32_t tv_nsec,
+    uint32_t refresh,
+    uint32_t seq_hi,
+    uint32_t seq_lo,
+    uint32_t flags) {
+  WaylandBufferManager* self = static_cast<WaylandBufferManager*>(data);
+  DCHECK(self);
+
+  for (auto& item : self->buffers_) {
+    Buffer* buffer = item.second.get();
+    if (buffer->wp_presentation_feedback.get() == wp_presentation_feedback) {
+      // Frame callback must come before a feedback is presented.
+      DCHECK(!buffer->wl_frame_callback);
+
+      buffer->feedback = gfx::PresentationFeedback(
+          GetPresentationFeedbackTimeStamp(tv_sec_hi, tv_sec_lo, tv_nsec),
+          base::TimeDelta::FromNanoseconds(refresh),
+          GetPresentationKindFlags(flags));
+
+      buffer->wp_presentation_feedback.reset();
+      self->OnBufferSwapped(buffer);
+      return;
+    }
+  }
+
+  NOTREACHED();
+}
+
+// static
+void WaylandBufferManager::FeedbackDiscarded(
+    void* data,
+    struct wp_presentation_feedback* wp_presentation_feedback) {
+  WaylandBufferManager* self = static_cast<WaylandBufferManager*>(data);
+  DCHECK(self);
+
+  for (auto& item : self->buffers_) {
+    Buffer* buffer = item.second.get();
+    if (buffer->wp_presentation_feedback.get() == wp_presentation_feedback) {
+      // Frame callback must come before a feedback is presented.
+      DCHECK(!buffer->wl_frame_callback);
+      buffer->feedback = gfx::PresentationFeedback();
+
+      buffer->wp_presentation_feedback.reset();
+      self->OnBufferSwapped(buffer);
       return;
     }
   }

--- a/src/ui/ozone/platform/wayland/wayland_buffer_manager.h
+++ b/src/ui/ozone/platform/wayland/wayland_buffer_manager.h
@@ -11,6 +11,7 @@
 #include "base/containers/flat_map.h"
 #include "base/files/file.h"
 #include "base/macros.h"
+#include "ui/gfx/geometry/rect.h"
 #include "ui/gfx/native_widget_types.h"
 #include "ui/gfx/presentation_feedback.h"
 #include "ui/gfx/swap_result.h"
@@ -56,9 +57,12 @@ class WaylandBufferManager {
                     uint32_t buffer_id);
 
   // Assigns a wl_buffer with |buffer_id| to a window with the same |widget|. On
-  // error, false is returned and |error_message_| is set.
+  // error, false is returned and |error_message_| is set. A |damage_region|
+  // identifies which part of the buffer is updated. If an empty region is
+  // provided, the whole buffer is updated.
   bool ScheduleBufferSwap(gfx::AcceleratedWidget widget,
                           uint32_t buffer_id,
+                          const gfx::Rect& damage_region,
                           wl::BufferSwapCallback callback);
 
   // Destroys a buffer with |buffer_id| in |buffers_|. On error, false is
@@ -86,6 +90,11 @@ class WaylandBufferManager {
 
     // Widget to attached/being attach WaylandWindow.
     gfx::AcceleratedWidget widget = gfx::kNullAcceleratedWidget;
+
+    // Describes the region where the pending buffer is different from the
+    // current surface contents, and where the surface therefore needs to be
+    // repainted.
+    gfx::Rect damage_region;
 
     // A buffer swap result once the buffer is committed.
     gfx::SwapResult swap_result;

--- a/src/ui/ozone/platform/wayland/wayland_buffer_manager.h
+++ b/src/ui/ozone/platform/wayland/wayland_buffer_manager.h
@@ -151,6 +151,8 @@ class WaylandBufferManager {
 
   void OnBufferSwapped(Buffer* buffer);
 
+  void AddSupportedFourCCFormat(uint32_t fourcc_format);
+
   // zwp_linux_dmabuf_v1_listener
   static void Modifiers(void* data,
                         struct zwp_linux_dmabuf_v1* zwp_linux_dmabuf,

--- a/src/ui/ozone/platform/wayland/wayland_buffer_manager.h
+++ b/src/ui/ozone/platform/wayland/wayland_buffer_manager.h
@@ -107,7 +107,7 @@ class WaylandBufferManager {
     zwp_linux_buffer_params_v1* params = nullptr;
 
     // A wl_buffer backed by a dmabuf created on the GPU side.
-    wl::Object<wl_buffer> wl_buffer;
+    wl::Object<struct wl_buffer> wl_buffer;
 
     // A callback, which is called once the |wl_frame_callback| from the server
     // is received.
@@ -120,7 +120,7 @@ class WaylandBufferManager {
 
     // A presentation feedback provided by the Wayland server once frame is
     // shown.
-    wl::Object<wp_presentation_feedback> wp_presentation_feedback;
+    wl::Object<struct wp_presentation_feedback> wp_presentation_feedback;
 
     DISALLOW_COPY_AND_ASSIGN(Buffer);
   };

--- a/src/ui/ozone/platform/wayland/wayland_buffer_manager.h
+++ b/src/ui/ozone/platform/wayland/wayland_buffer_manager.h
@@ -82,11 +82,16 @@ class WaylandBufferManager {
   // to this Buffer object on run-time.
   struct Buffer {
     Buffer();
-    Buffer(uint32_t id, zwp_linux_buffer_params_v1* zwp_params);
+    Buffer(uint32_t id,
+           zwp_linux_buffer_params_v1* zwp_params,
+           const gfx::Size& buffer_size);
     ~Buffer();
 
     // GPU GbmPixmapWayland corresponding buffer id.
     uint32_t buffer_id = 0;
+
+    // Actual buffer size.
+    const gfx::Size size;
 
     // Widget to attached/being attach WaylandWindow.
     gfx::AcceleratedWidget widget = gfx::kNullAcceleratedWidget;

--- a/src/ui/ozone/platform/wayland/wayland_buffer_manager.h
+++ b/src/ui/ozone/platform/wayland/wayland_buffer_manager.h
@@ -35,7 +35,7 @@ class WaylandBufferManager {
 
   std::string error_message() { return std::move(error_message_); }
 
-  const std::vector<gfx::BufferFormat>& supported_buffer_formats() {
+  std::vector<gfx::BufferFormat> supported_buffer_formats() {
     return supported_buffer_formats_;
   }
 

--- a/src/ui/ozone/platform/wayland/wayland_buffer_manager.h
+++ b/src/ui/ozone/platform/wayland/wayland_buffer_manager.h
@@ -1,0 +1,130 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_BUFFER_MANAGER_H_
+#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_BUFFER_MANAGER_H_
+
+#include <map>
+#include <vector>
+
+#include "base/containers/flat_map.h"
+#include "base/files/file.h"
+#include "base/macros.h"
+#include "ui/gfx/native_widget_types.h"
+#include "ui/ozone/platform/wayland/wayland_object.h"
+
+struct zwp_linux_dmabuf_v1;
+struct zwp_linux_buffer_params_v1;
+
+namespace gfx {
+enum class BufferFormat;
+}  // namespace gfx
+
+namespace ui {
+
+class WaylandConnection;
+
+// The manager uses zwp_linux_dmabuf protocol to create wl_buffers from added
+// dmabuf buffers. Only used when GPU runs in own process.
+class WaylandBufferManager {
+ public:
+  WaylandBufferManager(zwp_linux_dmabuf_v1* zwp_linux_dmabuf,
+                       WaylandConnection* connection);
+  ~WaylandBufferManager();
+
+  std::string error_message() { return std::move(error_message_); }
+
+  const std::vector<gfx::BufferFormat>& supported_buffer_formats() {
+    return supported_buffer_formats_;
+  }
+
+  // Creates a wl_buffer based on the dmabuf |file| descriptor. On error, false
+  // is returned and |error_message_| is set.
+  bool CreateBuffer(base::File file,
+                    uint32_t width,
+                    uint32_t height,
+                    const std::vector<uint32_t>& strides,
+                    const std::vector<uint32_t>& offsets,
+                    uint32_t format,
+                    const std::vector<uint64_t>& modifiers,
+                    uint32_t planes_count,
+                    uint32_t buffer_id);
+
+  // Assigns a wl_buffer with |buffer_id| to a window with the same |widget|. On
+  // error, false is returned and |error_message_| is set.
+  bool SwapBuffer(gfx::AcceleratedWidget widget, uint32_t buffer_id);
+
+  // Destroys a buffer with |buffer_id| in |buffers_|. On error, false is
+  // returned and |error_message_| is set.
+  bool DestroyBuffer(uint32_t buffer_id);
+
+  // Destroys all the data and buffers stored in own containers.
+  void ClearState();
+
+ private:
+  // Validates data sent from GPU. If invalid, returns false and sets an error
+  // message to |error_message_|.
+  bool ValidateDataFromGpu(const base::File& file,
+                           uint32_t width,
+                           uint32_t height,
+                           const std::vector<uint32_t>& strides,
+                           const std::vector<uint32_t>& offsets,
+                           uint32_t format,
+                           const std::vector<uint64_t>& modifiers,
+                           uint32_t planes_count,
+                           uint32_t buffer_id);
+  bool ValidateDataFromGpu(const gfx::AcceleratedWidget& widget,
+                           uint32_t buffer_id);
+
+  void CreateSucceededInternal(struct zwp_linux_buffer_params_v1* params,
+                               struct wl_buffer* new_buffer);
+
+  // zwp_linux_dmabuf_v1_listener
+  static void Modifiers(void* data,
+                        struct zwp_linux_dmabuf_v1* zwp_linux_dmabuf,
+                        uint32_t format,
+                        uint32_t modifier_hi,
+                        uint32_t modifier_lo);
+  static void Format(void* data,
+                     struct zwp_linux_dmabuf_v1* zwp_linux_dmabuf,
+                     uint32_t format);
+
+  // zwp_linux_buffer_params_v1_listener
+  static void CreateSucceeded(void* data,
+                              struct zwp_linux_buffer_params_v1* params,
+                              struct wl_buffer* new_buffer);
+  static void CreateFailed(void* data,
+                           struct zwp_linux_buffer_params_v1* params);
+
+  // Stores a wl_buffer and it's id provided by the GbmBuffer object on the
+  // GPU process side.
+  base::flat_map<uint32_t, wl::Object<wl_buffer>> buffers_;
+
+  // A temporary params-to-buffer id map, which is used to identify which
+  // id wl_buffer should be assigned when storing it in the |buffers_| map
+  // during CreateSucceeded call.
+  base::flat_map<struct zwp_linux_buffer_params_v1*, uint32_t>
+      params_to_id_map_;
+
+  // It might happen that GPU asks to swap buffers, when a wl_buffer hasn't
+  // been created yet. Thus, store the request in a pending map. Once a buffer
+  // is created, it will be attached to the requested WaylandWindow based on the
+  // gfx::AcceleratedWidget.
+  base::flat_map<uint32_t, gfx::AcceleratedWidget> pending_buffer_map_;
+
+  // Stores announced buffer formats supported by the compositor.
+  std::vector<gfx::BufferFormat> supported_buffer_formats_;
+
+  // Set when invalid data is received from the GPU process.
+  std::string error_message_;
+
+  wl::Object<zwp_linux_dmabuf_v1> zwp_linux_dmabuf_;
+
+  // Non-owned pointer to the main connection.
+  WaylandConnection* connection_ = nullptr;
+};
+
+}  // namespace ui
+
+#endif  // UI_OZONE_PLATFORM_WAYLAND_WAYLAND_BUFFER_MANAGER_H_

--- a/src/ui/ozone/platform/wayland/wayland_connection.cc
+++ b/src/ui/ozone/platform/wayland/wayland_connection.cc
@@ -4,9 +4,6 @@
 
 #include "ui/ozone/platform/wayland/wayland_connection.h"
 
-#include <drm_fourcc.h>
-
-#include <linux-dmabuf-unstable-v1-client-protocol.h>
 #include <xdg-shell-unstable-v5-client-protocol.h>
 #include <xdg-shell-unstable-v6-client-protocol.h>
 
@@ -17,8 +14,7 @@
 #include "base/message_loop/message_loop_current.h"
 #include "base/strings/string_util.h"
 #include "base/threading/thread_task_runner_handle.h"
-#include "base/trace_event/trace_event.h"
-#include "ui/ozone/common/linux/drm_util_linux.h"
+#include "ui/ozone/platform/wayland/wayland_buffer_manager.h"
 #include "ui/ozone/platform/wayland/wayland_input_method_context.h"
 #include "ui/ozone/platform/wayland/wayland_object.h"
 #include "ui/ozone/platform/wayland/wayland_output_manager.h"
@@ -27,6 +23,7 @@
 static_assert(XDG_SHELL_VERSION_CURRENT == 5, "Unsupported xdg-shell version");
 
 namespace ui {
+
 namespace {
 const uint32_t kMaxCompositorVersion = 4;
 const uint32_t kMaxLinuxDmabufVersion = 1;
@@ -47,10 +44,7 @@ std::unique_ptr<WaylandDataSource> CreateWaylandDataSource(
 WaylandConnection::WaylandConnection()
     : controller_(FROM_HERE), binding_(this) {}
 
-WaylandConnection::~WaylandConnection() {
-  DCHECK(pending_buffer_map_.empty() && params_to_id_map_.empty() &&
-         buffers_.empty());
-}
+WaylandConnection::~WaylandConnection() = default;
 
 bool WaylandConnection::Initialize() {
   static const wl_registry_listener registry_listener = {
@@ -170,47 +164,6 @@ int WaylandConnection::GetKeyboardModifiers() {
   return modifiers;
 }
 
-// TODO(msisov): handle buffer swap failure or success.
-void WaylandConnection::ScheduleBufferSwap(const gfx::AcceleratedWidget& widget,
-                                           uint32_t buffer_id) {
-  DCHECK(base::MessageLoopForUI::IsCurrent());
-  if (!ValidateDataFromGpu(widget, buffer_id))
-    return;
-
-  auto it = buffers_.find(buffer_id);
-  // A buffer might not exist by this time. So, store the request and process
-  // it once it is created.
-  if (it == buffers_.end()) {
-    auto pending_buffers_it = pending_buffer_map_.find(buffer_id);
-    if (pending_buffers_it != pending_buffer_map_.end()) {
-      // If a buffer didn't exist and second call for a swap comes, buffer must
-      // be associated with the same widget.
-      DCHECK_EQ(pending_buffers_it->second, widget);
-    } else {
-      pending_buffer_map_.insert(
-          std::pair<uint32_t, gfx::AcceleratedWidget>(buffer_id, widget));
-    }
-    return;
-  }
-  struct wl_buffer* buffer = it->second.get();
-
-  WaylandWindow* window = GetWindow(widget);
-  if (!window)
-    return;
-
-  // TODO(msisov): it would be beneficial to use real damage regions to improve
-  // performance.
-  //
-  // TODO(msisov): also start using wl_surface_frame callbacks for better
-  // performance.
-  wl_surface_damage(window->surface(), 0, 0, window->GetBounds().width(),
-                    window->GetBounds().height());
-  wl_surface_attach(window->surface(), buffer, 0, 0);
-  wl_surface_commit(window->surface());
-
-  ScheduleFlush();
-}
-
 void WaylandConnection::CreateZwpLinuxDmabuf(
     base::File file,
     uint32_t width,
@@ -221,101 +174,31 @@ void WaylandConnection::CreateZwpLinuxDmabuf(
     const std::vector<uint64_t>& modifiers,
     uint32_t planes_count,
     uint32_t buffer_id) {
-  TRACE_EVENT2("Wayland", "WaylandConnection::CreateZwpLinuxDmabuf", "Format",
-               format, "Buffer id", buffer_id);
-
-  static const struct zwp_linux_buffer_params_v1_listener params_listener = {
-      WaylandConnection::CreateSucceeded, WaylandConnection::CreateFailed};
-
   DCHECK(base::MessageLoopForUI::IsCurrent());
-  if (!ValidateDataFromGpu(file, width, height, strides, offsets, format,
-                           modifiers, planes_count, buffer_id)) {
-    // base::File::Close() has an assertion that checks if blocking operations
-    // are allowed. Thus, manually close the fd here.
-    base::ScopedFD fd(file.TakePlatformFile());
-    fd.reset();
-    return;
+  if (!buffer_manager_->CreateBuffer(std::move(file), width, height, strides,
+                                     offsets, format, modifiers, planes_count,
+                                     buffer_id)) {
+    TerminateGpuProcess(buffer_manager_->error_message());
   }
-
-  // Store |params| connected to |buffer_id| to track buffer creation and
-  // identify, which buffer a client wants to use.
-  struct zwp_linux_buffer_params_v1* params =
-      zwp_linux_dmabuf_v1_create_params(zwp_linux_dmabuf());
-  params_to_id_map_.insert(
-      std::pair<struct zwp_linux_buffer_params_v1*, uint32_t>(params,
-                                                              buffer_id));
-  uint32_t fd = file.TakePlatformFile();
-  for (size_t i = 0; i < planes_count; i++) {
-    zwp_linux_buffer_params_v1_add(params, fd, i /* plane id */, offsets[i],
-                                   strides[i], 0 /* modifier hi */,
-                                   0 /* modifier lo */);
-  }
-  zwp_linux_buffer_params_v1_add_listener(params, &params_listener, this);
-  zwp_linux_buffer_params_v1_create(params, width, height, format, 0);
-
-  ScheduleFlush();
 }
 
 void WaylandConnection::DestroyZwpLinuxDmabuf(uint32_t buffer_id) {
-  TRACE_EVENT1("Wayland", "WaylandConnection::DestroyZwpLinuxDmabuf",
-               "Buffer id", buffer_id);
-
   DCHECK(base::MessageLoopForUI::IsCurrent());
-
-  auto it = buffers_.find(buffer_id);
-  if (it == buffers_.end()) {
-    TerminateGpuProcess("Trying to destroy non-existing buffer");
-    return;
+  if (!buffer_manager_->DestroyBuffer(buffer_id)) {
+    TerminateGpuProcess(buffer_manager_->error_message());
   }
-  buffers_.erase(it);
+}
 
-  ScheduleFlush();
+void WaylandConnection::ScheduleBufferSwap(const gfx::AcceleratedWidget& widget,
+                                           uint32_t buffer_id) {
+  DCHECK(base::MessageLoopForUI::IsCurrent());
+  if (!buffer_manager_->SwapBuffer(widget, buffer_id)) {
+    TerminateGpuProcess(buffer_manager_->error_message());
+  }
 }
 
 ClipboardDelegate* WaylandConnection::GetClipboardDelegate() {
   return this;
-}
-
-// static
-void WaylandConnection::CreateSucceeded(
-    void* data,
-    struct zwp_linux_buffer_params_v1* params,
-    struct wl_buffer* new_buffer) {
-  DCHECK(base::MessageLoopForUI::IsCurrent());
-
-  WaylandConnection* connection = static_cast<WaylandConnection*>(data);
-  DCHECK(connection);
-
-  // Find which buffer id |params| belong to and store wl_buffer
-  // with that id.
-  auto it = connection->params_to_id_map_.find(params);
-  CHECK(it != connection->params_to_id_map_.end());
-  uint32_t buffer_id = it->second;
-  connection->params_to_id_map_.erase(params);
-  zwp_linux_buffer_params_v1_destroy(params);
-
-  connection->buffers_.insert(std::pair<uint32_t, wl::Object<wl_buffer>>(
-      buffer_id, wl::Object<wl_buffer>(new_buffer)));
-
-  TRACE_EVENT1("Wayland", "WaylandConnection::CreateSucceeded", "Buffer id",
-               buffer_id);
-
-  auto pending_buffers_it = connection->pending_buffer_map_.find(buffer_id);
-  if (pending_buffers_it != connection->pending_buffer_map_.end()) {
-    gfx::AcceleratedWidget widget = pending_buffers_it->second;
-    connection->pending_buffer_map_.erase(pending_buffers_it);
-    connection->ScheduleBufferSwap(widget, buffer_id);
-  }
-}
-
-// static
-void WaylandConnection::CreateFailed(
-    void* data,
-    struct zwp_linux_buffer_params_v1* params) {
-  DCHECK(base::MessageLoopForUI::IsCurrent());
-
-  zwp_linux_buffer_params_v1_destroy(params);
-  LOG(FATAL) << "zwp_linux_buffer_params.create failed";
 }
 
 void WaylandConnection::OfferClipboardData(
@@ -347,14 +230,16 @@ bool WaylandConnection::IsSelectionOwner() {
 ozone::mojom::WaylandConnectionPtr WaylandConnection::BindInterface() {
   // This mustn't be called twice or when the zwp_linux_dmabuf interface is not
   // available.
-  DCHECK(!binding_.is_bound() || zwp_linux_dmabuf_);
+  DCHECK(!binding_.is_bound() || buffer_manager_);
   ozone::mojom::WaylandConnectionPtr ptr;
   binding_.Bind(MakeRequest(&ptr));
   return ptr;
 }
 
-std::vector<gfx::BufferFormat> WaylandConnection::GetSupportedBufferFormats() {
-  return buffer_formats_;
+const std::vector<gfx::BufferFormat>&
+WaylandConnection::GetSupportedBufferFormats() {
+  DCHECK(buffer_manager_);
+  return buffer_manager_->supported_buffer_formats();
 }
 
 void WaylandConnection::SetTerminateGpuCallback(
@@ -444,79 +329,10 @@ void WaylandConnection::OnFileCanReadWithoutBlocking(int fd) {
 
 void WaylandConnection::OnFileCanWriteWithoutBlocking(int fd) {}
 
-bool WaylandConnection::ValidateDataFromGpu(
-    const base::File& file,
-    uint32_t width,
-    uint32_t height,
-    const std::vector<uint32_t>& strides,
-    const std::vector<uint32_t>& offsets,
-    uint32_t format,
-    const std::vector<uint64_t>& modifiers,
-    uint32_t planes_count,
-    uint32_t buffer_id) {
-  std::string reason;
-  if (!file.IsValid())
-    reason = "Buffer fd is invalid";
-
-  if (width == 0 || height == 0)
-    reason = "Buffer size is invalid";
-
-  if (planes_count < 1)
-    reason = "Planes count cannot be less than 1";
-
-  if (planes_count != strides.size() || planes_count != offsets.size() ||
-      planes_count != modifiers.size()) {
-    reason = "Number of strides(" + std::to_string(strides.size()) +
-             ")/offsets(" + std::to_string(offsets.size()) + ")/modifiers(" +
-             std::to_string(modifiers.size()) +
-             ") does not correspond to the number of planes(" +
-             std::to_string(planes_count) + ")";
-  }
-
-  for (auto stride : strides) {
-    if (stride == 0)
-      reason = "Strides are invalid";
-  }
-
-  if (!IsValidBufferFormat(format))
-    reason = "Buffer format is invalid";
-
-  if (buffer_id < 1)
-    reason = "Invalid buffer id: " + std::to_string(buffer_id);
-
-  if (!reason.empty()) {
-    TerminateGpuProcess(reason);
-    return false;
-  }
-  return true;
-}
-
-bool WaylandConnection::ValidateDataFromGpu(
-    const gfx::AcceleratedWidget& widget,
-    uint32_t buffer_id) {
-  std::string reason;
-
-  if (widget == gfx::kNullAcceleratedWidget)
-    reason = "Invalid accelerated widget";
-
-  if (buffer_id < 1)
-    reason = "Invalid buffer id: " + std::to_string(buffer_id);
-
-  if (!reason.empty()) {
-    TerminateGpuProcess(reason);
-    return false;
-  }
-
-  return true;
-}
-
 void WaylandConnection::TerminateGpuProcess(std::string reason) {
   std::move(terminate_gpu_cb_).Run(std::move(reason));
   binding_.Unbind();
-
-  buffers_.clear();
-  params_to_id_map_.clear();
-  pending_buffer_map_.clear();
+  buffer_manager_->ClearState();
 }
 
 // static
@@ -533,9 +349,6 @@ void WaylandConnection::Global(void* data,
   };
   static const zxdg_shell_v6_listener shell_v6_listener = {
       &WaylandConnection::PingV6,
-  };
-  static const zwp_linux_dmabuf_v1_listener dmabuf_listener = {
-      &WaylandConnection::Format, &WaylandConnection::Modifiers,
   };
 
   WaylandConnection* connection = static_cast<WaylandConnection*>(data);
@@ -623,15 +436,13 @@ void WaylandConnection::Global(void* data,
     connection->data_device_manager_.reset(
         new WaylandDataDeviceManager(data_device_manager.release()));
     connection->data_device_manager_->set_connection(connection);
-  } else if (!connection->zwp_linux_dmabuf_ &&
+  } else if (!connection->buffer_manager_ &&
              (strcmp(interface, "zwp_linux_dmabuf_v1") == 0)) {
-    connection->zwp_linux_dmabuf_ = wl::Bind<zwp_linux_dmabuf_v1>(
-        registry, name, std::min(version, kMaxLinuxDmabufVersion));
-    zwp_linux_dmabuf_v1_add_listener(connection->zwp_linux_dmabuf(),
-                                     &dmabuf_listener, connection);
-    // A roundtrip after binding guarantees that the client has received all
-    // supported formats.
-    wl_display_roundtrip(connection->display_.get());
+    wl::Object<zwp_linux_dmabuf_v1> zwp_linux_dmabuf =
+        wl::Bind<zwp_linux_dmabuf_v1>(
+            registry, name, std::min(version, kMaxLinuxDmabufVersion));
+    connection->buffer_manager_.reset(
+        new WaylandBufferManager(zwp_linux_dmabuf.release(), connection));
   } else if (!connection->text_input_manager_v1_ &&
              strcmp(interface, "zwp_text_input_manager_v1") == 0) {
     connection->text_input_manager_v1_ = wl::Bind<zwp_text_input_manager_v1>(
@@ -730,27 +541,6 @@ void WaylandConnection::Ping(void* data, xdg_shell* shell, uint32_t serial) {
   WaylandConnection* connection = static_cast<WaylandConnection*>(data);
   xdg_shell_pong(shell, serial);
   connection->ScheduleFlush();
-}
-
-// static
-void WaylandConnection::Modifiers(void* data,
-                                  struct zwp_linux_dmabuf_v1* zwp_linux_dmabuf,
-                                  uint32_t format,
-                                  uint32_t modifier_hi,
-                                  uint32_t modifier_lo) {
-  NOTIMPLEMENTED();
-}
-
-// static
-void WaylandConnection::Format(void* data,
-                               struct zwp_linux_dmabuf_v1* zwp_linux_dmabuf,
-                               uint32_t format) {
-  WaylandConnection* connection = static_cast<WaylandConnection*>(data);
-  // Return on not the supported ARGB format.
-  if (format == DRM_FORMAT_ARGB2101010)
-    return;
-  connection->buffer_formats_.push_back(
-      GetBufferFormatFromFourCCFormat(format));
 }
 
 }  // namespace ui

--- a/src/ui/ozone/platform/wayland/wayland_connection.cc
+++ b/src/ui/ozone/platform/wayland/wayland_connection.cc
@@ -236,10 +236,10 @@ ozone::mojom::WaylandConnectionPtr WaylandConnection::BindInterface() {
   return ptr;
 }
 
-const std::vector<gfx::BufferFormat>&
-WaylandConnection::GetSupportedBufferFormats() {
-  DCHECK(buffer_manager_);
-  return buffer_manager_->supported_buffer_formats();
+std::vector<gfx::BufferFormat> WaylandConnection::GetSupportedBufferFormats() {
+  if (buffer_manager_)
+    return buffer_manager_->supported_buffer_formats();
+  return std::vector<gfx::BufferFormat>();
 }
 
 void WaylandConnection::SetTerminateGpuCallback(

--- a/src/ui/ozone/platform/wayland/wayland_connection.cc
+++ b/src/ui/ozone/platform/wayland/wayland_connection.cc
@@ -14,6 +14,7 @@
 #include "base/message_loop/message_loop_current.h"
 #include "base/strings/string_util.h"
 #include "base/threading/thread_task_runner_handle.h"
+#include "ui/gfx/swap_result.h"
 #include "ui/ozone/platform/wayland/wayland_buffer_manager.h"
 #include "ui/ozone/platform/wayland/wayland_input_method_context.h"
 #include "ui/ozone/platform/wayland/wayland_object.h"
@@ -189,10 +190,13 @@ void WaylandConnection::DestroyZwpLinuxDmabuf(uint32_t buffer_id) {
   }
 }
 
-void WaylandConnection::ScheduleBufferSwap(const gfx::AcceleratedWidget& widget,
-                                           uint32_t buffer_id) {
+void WaylandConnection::ScheduleBufferSwap(
+    const gfx::AcceleratedWidget& widget,
+    uint32_t buffer_id,
+    ScheduleBufferSwapCallback callback) {
   DCHECK(base::MessageLoopForUI::IsCurrent());
-  if (!buffer_manager_->ScheduleBufferSwap(widget, buffer_id)) {
+  if (!buffer_manager_->ScheduleBufferSwap(widget, buffer_id,
+                                           std::move(callback))) {
     TerminateGpuProcess(buffer_manager_->error_message());
   }
 }

--- a/src/ui/ozone/platform/wayland/wayland_connection.cc
+++ b/src/ui/ozone/platform/wayland/wayland_connection.cc
@@ -26,13 +26,14 @@ static_assert(XDG_SHELL_VERSION_CURRENT == 5, "Unsupported xdg-shell version");
 namespace ui {
 
 namespace {
-const uint32_t kMaxCompositorVersion = 4;
-const uint32_t kMaxLinuxDmabufVersion = 1;
-const uint32_t kMaxSeatVersion = 4;
-const uint32_t kMaxShmVersion = 1;
-const uint32_t kMaxXdgShellVersion = 1;
-const uint32_t kMaxDeviceManagerVersion = 3;
+constexpr uint32_t kMaxCompositorVersion = 4;
+constexpr uint32_t kMaxLinuxDmabufVersion = 1;
+constexpr uint32_t kMaxSeatVersion = 4;
+constexpr uint32_t kMaxShmVersion = 1;
+constexpr uint32_t kMaxXdgShellVersion = 1;
+constexpr uint32_t kMaxDeviceManagerVersion = 3;
 constexpr uint32_t kMaxTextInputManagerVersion = 1;
+constexpr uint32_t kMaxWpPresentationVersion = 1;
 
 std::unique_ptr<WaylandDataSource> CreateWaylandDataSource(
     WaylandDataDeviceManager* data_device_manager,
@@ -455,6 +456,10 @@ void WaylandConnection::Global(void* data,
       LOG(ERROR) << "Failed to bind to zwp_text_input_manager_v1 global";
       return;
     }
+  } else if (!connection->presentation_ &&
+             (strcmp(interface, "wp_presentation") == 0)) {
+    connection->presentation_ =
+        wl::Bind<wp_presentation>(registry, name, kMaxWpPresentationVersion);
   }
 
   connection->ScheduleFlush();

--- a/src/ui/ozone/platform/wayland/wayland_connection.cc
+++ b/src/ui/ozone/platform/wayland/wayland_connection.cc
@@ -27,7 +27,7 @@ namespace ui {
 
 namespace {
 constexpr uint32_t kMaxCompositorVersion = 4;
-constexpr uint32_t kMaxLinuxDmabufVersion = 1;
+constexpr uint32_t kMaxLinuxDmabufVersion = 3;
 constexpr uint32_t kMaxSeatVersion = 4;
 constexpr uint32_t kMaxShmVersion = 1;
 constexpr uint32_t kMaxXdgShellVersion = 1;

--- a/src/ui/ozone/platform/wayland/wayland_connection.cc
+++ b/src/ui/ozone/platform/wayland/wayland_connection.cc
@@ -194,9 +194,10 @@ void WaylandConnection::DestroyZwpLinuxDmabuf(uint32_t buffer_id) {
 void WaylandConnection::ScheduleBufferSwap(
     const gfx::AcceleratedWidget& widget,
     uint32_t buffer_id,
+    const gfx::Rect& damage_region,
     ScheduleBufferSwapCallback callback) {
   DCHECK(base::MessageLoopForUI::IsCurrent());
-  if (!buffer_manager_->ScheduleBufferSwap(widget, buffer_id,
+  if (!buffer_manager_->ScheduleBufferSwap(widget, buffer_id, damage_region,
                                            std::move(callback))) {
     TerminateGpuProcess(buffer_manager_->error_message());
   }

--- a/src/ui/ozone/platform/wayland/wayland_connection.cc
+++ b/src/ui/ozone/platform/wayland/wayland_connection.cc
@@ -192,7 +192,7 @@ void WaylandConnection::DestroyZwpLinuxDmabuf(uint32_t buffer_id) {
 void WaylandConnection::ScheduleBufferSwap(const gfx::AcceleratedWidget& widget,
                                            uint32_t buffer_id) {
   DCHECK(base::MessageLoopForUI::IsCurrent());
-  if (!buffer_manager_->SwapBuffer(widget, buffer_id)) {
+  if (!buffer_manager_->ScheduleBufferSwap(widget, buffer_id)) {
     TerminateGpuProcess(buffer_manager_->error_message());
   }
 }

--- a/src/ui/ozone/platform/wayland/wayland_connection.h
+++ b/src/ui/ozone/platform/wayland/wayland_connection.h
@@ -62,6 +62,7 @@ class WaylandConnection : public PlatformEventSource,
   // WaylandWindow with the specified |widget|.
   void ScheduleBufferSwap(const gfx::AcceleratedWidget& widget,
                           uint32_t buffer_id,
+                          const gfx::Rect& damage_region,
                           ScheduleBufferSwapCallback callback) override;
 
   // Schedules a flush of the Wayland connection.

--- a/src/ui/ozone/platform/wayland/wayland_connection.h
+++ b/src/ui/ozone/platform/wayland/wayland_connection.h
@@ -78,6 +78,7 @@ class WaylandConnection : public PlatformEventSource,
   zwp_text_input_manager_v1* text_input_manager_v1() {
     return text_input_manager_v1_.get();
   }
+  wp_presentation* presentation() const { return presentation_.get(); }
 
   WaylandWindow* GetWindow(gfx::AcceleratedWidget widget);
   WaylandWindow* GetCurrentFocusedWindow();
@@ -198,6 +199,7 @@ class WaylandConnection : public PlatformEventSource,
   wl::Object<xdg_shell> shell_;
   wl::Object<zxdg_shell_v6> shell_v6_;
   wl::Object<zwp_text_input_manager_v1> text_input_manager_v1_;
+  wl::Object<wp_presentation> presentation_;
 
   std::unique_ptr<WaylandDataDeviceManager> data_device_manager_;
   std::unique_ptr<WaylandDataDevice> data_device_;

--- a/src/ui/ozone/platform/wayland/wayland_connection.h
+++ b/src/ui/ozone/platform/wayland/wayland_connection.h
@@ -7,12 +7,11 @@
 
 #include <map>
 
-#include "ui/gfx/buffer_types.h"
-
 #include "base/files/file.h"
 #include "base/message_loop/message_pump_libevent.h"
 #include "mojo/public/cpp/bindings/binding.h"
 #include "ui/events/platform/platform_event_source.h"
+#include "ui/gfx/buffer_types.h"
 #include "ui/gfx/native_widget_types.h"
 #include "ui/ozone/platform/wayland/wayland_data_device.h"
 #include "ui/ozone/platform/wayland/wayland_data_device_manager.h"
@@ -23,16 +22,13 @@
 #include "ui/ozone/platform/wayland/wayland_pointer.h"
 #include "ui/ozone/platform/wayland/wayland_touch.h"
 #include "ui/ozone/public/clipboard_delegate.h"
-#include "ui/ozone/public/gpu_platform_support_host.h"
 #include "ui/ozone/public/interfaces/wayland/wayland_connection.mojom.h"
-
-struct zwp_linux_dmabuf_v1;
-struct zwp_linux_buffer_params_v1;
 
 namespace ui {
 
 class WaylandOutputManager;
 class WaylandWindow;
+class WaylandBufferManager;
 
 class WaylandConnection : public PlatformEventSource,
                           public ClipboardDelegate,
@@ -47,7 +43,7 @@ class WaylandConnection : public PlatformEventSource,
 
   // ozone::mojom::WaylandConnection overrides:
   //
-  // The overridden methods below are invoked by GPU.
+  // These overridden methods below are invoked by the GPU.
   //
   // Called by the GPU and asks to import a wl_buffer based on a gbm file
   // descriptor.
@@ -78,7 +74,6 @@ class WaylandConnection : public PlatformEventSource,
   zxdg_shell_v6* shell_v6() const { return shell_v6_.get(); }
   wl_seat* seat() { return seat_.get(); }
   wl_data_device* data_device() { return data_device_->data_device(); }
-  zwp_linux_dmabuf_v1* zwp_linux_dmabuf() { return zwp_linux_dmabuf_.get(); }
   zwp_text_input_manager_v1* text_input_manager_v1() {
     return text_input_manager_v1_.get();
   }
@@ -127,7 +122,7 @@ class WaylandConnection : public PlatformEventSource,
   // Returns bound pointer to own mojo interface.
   ozone::mojom::WaylandConnectionPtr BindInterface();
 
-  std::vector<gfx::BufferFormat> GetSupportedBufferFormats();
+  const std::vector<gfx::BufferFormat>& GetSupportedBufferFormats();
 
   void SetTerminateGpuCallback(
       base::OnceCallback<void(std::string)> terminate_gpu_cb);
@@ -170,19 +165,6 @@ class WaylandConnection : public PlatformEventSource,
   void OnFileCanReadWithoutBlocking(int fd) override;
   void OnFileCanWriteWithoutBlocking(int fd) override;
 
-  // Validates data sent by the GPU. If anything, terminates the gpu process.
-  bool ValidateDataFromGpu(const base::File& file,
-                           uint32_t width,
-                           uint32_t height,
-                           const std::vector<uint32_t>& strides,
-                           const std::vector<uint32_t>& offsets,
-                           uint32_t format,
-                           const std::vector<uint64_t>& modifiers,
-                           uint32_t planes_count,
-                           uint32_t buffer_id);
-  bool ValidateDataFromGpu(const gfx::AcceleratedWidget& widget,
-                           uint32_t buffer_id);
-
   // Terminates the GPU process on invalid data received
   void TerminateGpuProcess(std::string reason);
 
@@ -204,22 +186,6 @@ class WaylandConnection : public PlatformEventSource,
   // xdg_shell_listener
   static void Ping(void* data, xdg_shell* shell, uint32_t serial);
 
-  // zwp_linux_dmabuf_v1_listener
-  static void Modifiers(void* data,
-                        struct zwp_linux_dmabuf_v1* zwp_linux_dmabuf,
-                        uint32_t format,
-                        uint32_t modifier_hi,
-                        uint32_t modifier_lo);
-  static void Format(void* data,
-                     struct zwp_linux_dmabuf_v1* zwp_linux_dmabuf,
-                     uint32_t format);
-
-  static void CreateSucceeded(void* data,
-                              struct zwp_linux_buffer_params_v1* params,
-                              struct wl_buffer* new_buffer);
-  static void CreateFailed(void* data,
-                           struct zwp_linux_buffer_params_v1* params);
-
   std::map<gfx::AcceleratedWidget, WaylandWindow*> window_map_;
 
   wl::Object<wl_display> display_;
@@ -229,23 +195,8 @@ class WaylandConnection : public PlatformEventSource,
   wl::Object<wl_seat> seat_;
   wl::Object<wl_shm> shm_;
   wl::Object<xdg_shell> shell_;
-  wl::Object<zwp_linux_dmabuf_v1> zwp_linux_dmabuf_;
   wl::Object<zxdg_shell_v6> shell_v6_;
   wl::Object<zwp_text_input_manager_v1> text_input_manager_v1_;
-
-  // Stores a wl_buffer and it's id provided by the GbmBuffer object on the
-  // GPU process side.
-  base::flat_map<uint32_t, wl::Object<wl_buffer>> buffers_;
-  // A temporary params-to-buffer id map, which is used to identify which
-  // id wl_buffer should be assigned when storing it in the |buffers_| map
-  // during CreateSucceeded call.
-  base::flat_map<struct zwp_linux_buffer_params_v1*, uint32_t>
-      params_to_id_map_;
-  // It might happen that GPU asks to swap buffers, when a wl_buffer hasn't
-  // been created yet. Thus, store the request in a pending map. Once buffer
-  // is created, it will be attached to requested WaylandWindow based on the
-  // gfx::AcceleratedWidget.
-  base::flat_map<uint32_t, gfx::AcceleratedWidget> pending_buffer_map_;
 
   std::unique_ptr<WaylandDataDeviceManager> data_device_manager_;
   std::unique_ptr<WaylandDataDevice> data_device_;
@@ -255,6 +206,9 @@ class WaylandConnection : public PlatformEventSource,
   std::unique_ptr<WaylandOutputManager> wayland_output_manager_;
   std::unique_ptr<WaylandPointer> pointer_;
   std::unique_ptr<WaylandTouch> touch_;
+
+  // Objects that are using when GPU runs in own process.
+  std::unique_ptr<WaylandBufferManager> buffer_manager_;
 
   bool scheduled_flush_ = false;
   bool watching_ = false;
@@ -270,8 +224,6 @@ class WaylandConnection : public PlatformEventSource,
   RequestDataClosure read_clipboard_closure_;
 
   mojo::Binding<ozone::mojom::WaylandConnection> binding_;
-
-  std::vector<gfx::BufferFormat> buffer_formats_;
 
   // A callback, which is used to terminate a GPU process in case of invalid
   // data sent by the GPU to the browser process.

--- a/src/ui/ozone/platform/wayland/wayland_connection.h
+++ b/src/ui/ozone/platform/wayland/wayland_connection.h
@@ -61,7 +61,8 @@ class WaylandConnection : public PlatformEventSource,
   // Called by the GPU and asks to attach a wl_buffer with a |buffer_id| to a
   // WaylandWindow with the specified |widget|.
   void ScheduleBufferSwap(const gfx::AcceleratedWidget& widget,
-                          uint32_t buffer_id) override;
+                          uint32_t buffer_id,
+                          ScheduleBufferSwapCallback callback) override;
 
   // Schedules a flush of the Wayland connection.
   void ScheduleFlush();

--- a/src/ui/ozone/platform/wayland/wayland_connection.h
+++ b/src/ui/ozone/platform/wayland/wayland_connection.h
@@ -122,7 +122,7 @@ class WaylandConnection : public PlatformEventSource,
   // Returns bound pointer to own mojo interface.
   ozone::mojom::WaylandConnectionPtr BindInterface();
 
-  const std::vector<gfx::BufferFormat>& GetSupportedBufferFormats();
+  std::vector<gfx::BufferFormat> GetSupportedBufferFormats();
 
   void SetTerminateGpuCallback(
       base::OnceCallback<void(std::string)> terminate_gpu_cb);

--- a/src/ui/ozone/platform/wayland/wayland_object.cc
+++ b/src/ui/ozone/platform/wayland/wayland_object.cc
@@ -5,6 +5,7 @@
 #include "ui/ozone/platform/wayland/wayland_object.h"
 
 #include <linux-dmabuf-unstable-v1-client-protocol.h>
+#include <presentation-time-client-protocol.h>
 #include <text-input-unstable-v1-client-protocol.h>
 #include <wayland-client.h>
 #include <xdg-shell-unstable-v5-client-protocol.h>
@@ -126,6 +127,16 @@ void (*ObjectTraits<wl_subsurface>::deleter)(wl_subsurface*) =
 
 const wl_interface* ObjectTraits<wl_touch>::interface = &wl_touch_interface;
 void (*ObjectTraits<wl_touch>::deleter)(wl_touch*) = &delete_touch;
+
+const wl_interface* ObjectTraits<wp_presentation>::interface =
+    &wp_presentation_interface;
+void (*ObjectTraits<wp_presentation>::deleter)(wp_presentation*) =
+    &wp_presentation_destroy;
+
+const wl_interface* ObjectTraits<struct wp_presentation_feedback>::interface =
+    &wp_presentation_feedback_interface;
+void (*ObjectTraits<struct wp_presentation_feedback>::deleter)(
+    struct wp_presentation_feedback*) = &wp_presentation_feedback_destroy;
 
 const wl_interface* ObjectTraits<xdg_shell>::interface = &xdg_shell_interface;
 void (*ObjectTraits<xdg_shell>::deleter)(xdg_shell*) = &xdg_shell_destroy;

--- a/src/ui/ozone/platform/wayland/wayland_object.h
+++ b/src/ui/ozone/platform/wayland/wayland_object.h
@@ -27,6 +27,8 @@ struct wl_subcompositor;
 struct wl_subsurface;
 struct wl_surface;
 struct wl_touch;
+struct wp_presentation;
+struct wp_presentation_feedback;
 struct xdg_shell;
 struct xdg_surface;
 struct xdg_popup;
@@ -156,6 +158,18 @@ template <>
 struct ObjectTraits<wl_touch> {
   static const wl_interface* interface;
   static void (*deleter)(wl_touch*);
+};
+
+template <>
+struct ObjectTraits<wp_presentation> {
+  static const wl_interface* interface;
+  static void (*deleter)(wp_presentation*);
+};
+
+template <>
+struct ObjectTraits<wp_presentation_feedback> {
+  static const wl_interface* interface;
+  static void (*deleter)(wp_presentation_feedback*);
 };
 
 template <>

--- a/src/ui/ozone/platform/wayland/wayland_surface_factory.cc
+++ b/src/ui/ozone/platform/wayland/wayland_surface_factory.cc
@@ -234,8 +234,10 @@ GbmSurfacelessWayland* WaylandSurfaceFactory::GetSurface(
 void WaylandSurfaceFactory::ScheduleBufferSwap(
     gfx::AcceleratedWidget widget,
     uint32_t buffer_id,
+    const gfx::Rect& damage_region,
     wl::BufferSwapCallback callback) {
-  connection_->ScheduleBufferSwap(widget, buffer_id, std::move(callback));
+  connection_->ScheduleBufferSwap(widget, buffer_id, damage_region,
+                                  std::move(callback));
 }
 
 std::unique_ptr<SurfaceOzoneCanvas>

--- a/src/ui/ozone/platform/wayland/wayland_surface_factory.cc
+++ b/src/ui/ozone/platform/wayland/wayland_surface_factory.cc
@@ -11,6 +11,7 @@
 #include "base/memory/ptr_util.h"
 #include "base/memory/shared_memory.h"
 #include "third_party/skia/include/core/SkSurface.h"
+#include "ui/gfx/linux/client_native_pixmap_dmabuf.h"
 #include "ui/gfx/vsync_provider.h"
 #include "ui/ozone/common/egl_util.h"
 #include "ui/ozone/common/gl_ozone_egl.h"

--- a/src/ui/ozone/platform/wayland/wayland_surface_factory.cc
+++ b/src/ui/ozone/platform/wayland/wayland_surface_factory.cc
@@ -231,9 +231,11 @@ GbmSurfacelessWayland* WaylandSurfaceFactory::GetSurface(
   return it->second;
 }
 
-void WaylandSurfaceFactory::ScheduleBufferSwap(gfx::AcceleratedWidget widget,
-                                               uint32_t buffer_id) {
-  connection_->ScheduleBufferSwap(widget, buffer_id);
+void WaylandSurfaceFactory::ScheduleBufferSwap(
+    gfx::AcceleratedWidget widget,
+    uint32_t buffer_id,
+    wl::BufferSwapCallback callback) {
+  connection_->ScheduleBufferSwap(widget, buffer_id, std::move(callback));
 }
 
 std::unique_ptr<SurfaceOzoneCanvas>

--- a/src/ui/ozone/platform/wayland/wayland_surface_factory.h
+++ b/src/ui/ozone/platform/wayland/wayland_surface_factory.h
@@ -13,11 +13,12 @@
 #include "base/posix/eintr_wrapper.h"
 #include "base/single_thread_task_runner.h"
 #include "base/threading/sequenced_task_runner_handle.h"
+#include "ui/ozone/platform/wayland/wayland_util.h"
 
 namespace ui {
 
-class WaylandConnectionProxy;
 class GbmSurfacelessWayland;
+class WaylandConnectionProxy;
 
 class WaylandSurfaceFactory : public SurfaceFactoryOzone {
  public:
@@ -25,7 +26,9 @@ class WaylandSurfaceFactory : public SurfaceFactoryOzone {
   ~WaylandSurfaceFactory() override;
 
   // These methods are used, when a dmabuf based approach is used.
-  void ScheduleBufferSwap(gfx::AcceleratedWidget widget, uint32_t buffer_id);
+  void ScheduleBufferSwap(gfx::AcceleratedWidget widget,
+                          uint32_t buffer_id,
+                          wl::BufferSwapCallback callback);
   void RegisterSurface(gfx::AcceleratedWidget widget,
                        GbmSurfacelessWayland* surface);
   void UnregisterSurface(gfx::AcceleratedWidget widget);

--- a/src/ui/ozone/platform/wayland/wayland_surface_factory.h
+++ b/src/ui/ozone/platform/wayland/wayland_surface_factory.h
@@ -7,13 +7,16 @@
 
 #include "base/macros.h"
 #include "base/memory/ref_counted.h"
-#include "ui/gl/gl_surface.h"
-#include "ui/ozone/public/surface_factory_ozone.h"
-
 #include "base/posix/eintr_wrapper.h"
 #include "base/single_thread_task_runner.h"
 #include "base/threading/sequenced_task_runner_handle.h"
+#include "ui/gl/gl_surface.h"
 #include "ui/ozone/platform/wayland/wayland_util.h"
+#include "ui/ozone/public/surface_factory_ozone.h"
+
+namespace gfx {
+class Rect;
+}  // namespace gfx
 
 namespace ui {
 
@@ -28,6 +31,7 @@ class WaylandSurfaceFactory : public SurfaceFactoryOzone {
   // These methods are used, when a dmabuf based approach is used.
   void ScheduleBufferSwap(gfx::AcceleratedWidget widget,
                           uint32_t buffer_id,
+                          const gfx::Rect& damage_region_,
                           wl::BufferSwapCallback callback);
   void RegisterSurface(gfx::AcceleratedWidget widget,
                        GbmSurfacelessWayland* surface);

--- a/src/ui/ozone/platform/wayland/wayland_util.h
+++ b/src/ui/ozone/platform/wayland/wayland_util.h
@@ -7,6 +7,7 @@
 
 #include <wayland-client.h>
 
+#include "base/callback.h"
 #include "base/macros.h"
 #include "ui/ozone/platform/wayland/wayland_object.h"
 
@@ -22,9 +23,13 @@ class WaylandConnection;
 
 namespace gfx {
 class Size;
+enum class SwapResult;
 }
 
 namespace wl {
+
+// Corresponds to mojom::WaylandConnection::ScheduleBufferSwapCallback.
+using BufferSwapCallback = base::OnceCallback<void(gfx::SwapResult)>;
 
 wl_buffer* CreateSHMBuffer(const gfx::Size& size,
                            base::SharedMemory* shared_memory,

--- a/src/ui/ozone/platform/wayland/wayland_util.h
+++ b/src/ui/ozone/platform/wayland/wayland_util.h
@@ -24,12 +24,14 @@ class WaylandConnection;
 namespace gfx {
 class Size;
 enum class SwapResult;
+struct PresentationFeedback;
 }
 
 namespace wl {
 
 // Corresponds to mojom::WaylandConnection::ScheduleBufferSwapCallback.
-using BufferSwapCallback = base::OnceCallback<void(gfx::SwapResult)>;
+using BufferSwapCallback =
+    base::OnceCallback<void(gfx::SwapResult, const gfx::PresentationFeedback&)>;
 
 wl_buffer* CreateSHMBuffer(const gfx::Size& size,
                            base::SharedMemory* shared_memory,

--- a/src/ui/ozone/public/interfaces/wayland/BUILD.gn
+++ b/src/ui/ozone/public/interfaces/wayland/BUILD.gn
@@ -11,6 +11,7 @@ mojom("wayland_interfaces") {
 
   public_deps = [
     "//mojo/public/mojom/base",
+    "//ui/gfx/geometry/mojo",
     "//ui/gfx/mojo",
   ]
 }

--- a/src/ui/ozone/public/interfaces/wayland/wayland_connection.mojom
+++ b/src/ui/ozone/public/interfaces/wayland/wayland_connection.mojom
@@ -6,6 +6,7 @@ module ui.ozone.mojom;
 
 import "mojo/public/mojom/base/file.mojom";
 import "mojo/public/mojom/base/file_path.mojom";
+import "ui/gfx/geometry/mojo/geometry.mojom";
 import "ui/gfx/mojo/accelerated_widget.mojom";
 import "ui/gfx/mojo/presentation_feedback.mojom";
 import "ui/gfx/mojo/swap_result.mojom";
@@ -28,7 +29,8 @@ interface WaylandConnection {
   DestroyZwpLinuxDmabuf(uint32 buffer_id);
 
   // Swaps wl_buffers for a WaylandWindow with the following |widget|.
-  ScheduleBufferSwap(gfx.mojom.AcceleratedWidget widget, uint32 buffer_id)
+  ScheduleBufferSwap(gfx.mojom.AcceleratedWidget widget, uint32 buffer_id,
+                     gfx.mojom.Rect damage_region)
       => (gfx.mojom.SwapResult swap_result,
           gfx.mojom.PresentationFeedback feedback);
 };

--- a/src/ui/ozone/public/interfaces/wayland/wayland_connection.mojom
+++ b/src/ui/ozone/public/interfaces/wayland/wayland_connection.mojom
@@ -7,6 +7,7 @@ module ui.ozone.mojom;
 import "mojo/public/mojom/base/file.mojom";
 import "mojo/public/mojom/base/file_path.mojom";
 import "ui/gfx/mojo/accelerated_widget.mojom";
+import "ui/gfx/mojo/swap_result.mojom";
 
 // Used by the GPU for communication with a WaylandConnection on the browser
 // process.
@@ -26,7 +27,8 @@ interface WaylandConnection {
   DestroyZwpLinuxDmabuf(uint32 buffer_id);
 
   // Swaps wl_buffers for a WaylandWindow with the following |widget|.
-  ScheduleBufferSwap(gfx.mojom.AcceleratedWidget widget, uint32 buffer_id);
+  ScheduleBufferSwap(gfx.mojom.AcceleratedWidget widget, uint32 buffer_id)
+        => (gfx.mojom.SwapResult swap_result);
 };
 
 // Used by the browser process to provide the GPU process with a mojo ptr to a

--- a/src/ui/ozone/public/interfaces/wayland/wayland_connection.mojom
+++ b/src/ui/ozone/public/interfaces/wayland/wayland_connection.mojom
@@ -7,6 +7,7 @@ module ui.ozone.mojom;
 import "mojo/public/mojom/base/file.mojom";
 import "mojo/public/mojom/base/file_path.mojom";
 import "ui/gfx/mojo/accelerated_widget.mojom";
+import "ui/gfx/mojo/presentation_feedback.mojom";
 import "ui/gfx/mojo/swap_result.mojom";
 
 // Used by the GPU for communication with a WaylandConnection on the browser
@@ -28,7 +29,8 @@ interface WaylandConnection {
 
   // Swaps wl_buffers for a WaylandWindow with the following |widget|.
   ScheduleBufferSwap(gfx.mojom.AcceleratedWidget widget, uint32 buffer_id)
-        => (gfx.mojom.SwapResult swap_result);
+      => (gfx.mojom.SwapResult swap_result,
+          gfx.mojom.PresentationFeedback feedback);
 };
 
 // Used by the browser process to provide the GPU process with a mojo ptr to a

--- a/src/ui/ozone/public/ozone_platform.cc
+++ b/src/ui/ozone/public/ozone_platform.cc
@@ -31,25 +31,6 @@ base::Lock& GetOzoneInstanceLock() {
 
 }  // namespace
 
-OzonePlatform::PlatformProperties::PlatformProperties() = default;
-
-OzonePlatform::PlatformProperties::PlatformProperties(
-    bool needs_request,
-    bool custom_frame_default,
-    bool can_use_system_title_bar,
-    bool requires_mojo_for_ipc,
-    std::vector<gfx::BufferFormat> buffer_formats)
-    : needs_view_owner_request(needs_request),
-      custom_frame_pref_default(custom_frame_default),
-      use_system_title_bar(can_use_system_title_bar),
-      requires_mojo(requires_mojo_for_ipc),
-      supported_buffer_formats(buffer_formats) {}
-
-OzonePlatform::PlatformProperties::~PlatformProperties() = default;
-
-OzonePlatform::PlatformProperties::PlatformProperties(
-    const PlatformProperties& other) = default;
-
 OzonePlatform::OzonePlatform() {
   GetOzoneInstanceLock().AssertAcquired();
   DCHECK(!instance_) << "There should only be a single OzonePlatform.";
@@ -131,6 +112,13 @@ void OzonePlatform::RegisterStartupCallback(
     inst = instance_;
   }
   std::move(callback).Run(inst);
+}
+
+bool OzonePlatform::IsNativePixmapConfigSupported(
+    gfx::BufferFormat format,
+    gfx::BufferUsage usage) const {
+  // Platform that support NativePixmap must override this method.
+  return false;
 }
 
 // static

--- a/src/ui/ozone/public/ozone_platform.cc
+++ b/src/ui/ozone/public/ozone_platform.cc
@@ -37,10 +37,12 @@ OzonePlatform::PlatformProperties::PlatformProperties(
     bool needs_request,
     bool custom_frame_default,
     bool can_use_system_title_bar,
+    bool requires_mojo_for_ipc,
     std::vector<gfx::BufferFormat> buffer_formats)
     : needs_view_owner_request(needs_request),
       custom_frame_pref_default(custom_frame_default),
       use_system_title_bar(can_use_system_title_bar),
+      requires_mojo(requires_mojo_for_ipc),
       supported_buffer_formats(buffer_formats) {}
 
 OzonePlatform::PlatformProperties::~PlatformProperties() = default;

--- a/src/ui/ozone/public/ozone_platform.h
+++ b/src/ui/ozone/public/ozone_platform.h
@@ -84,15 +84,6 @@ class OZONE_EXPORT OzonePlatform {
 
   // Struct used to indicate platform properties.
   struct PlatformProperties {
-    PlatformProperties();
-    PlatformProperties(bool needs_request,
-                       bool custom_frame_default,
-                       bool can_use_system_title_bar,
-                       bool requires_mojo_for_ipc,
-                       std::vector<gfx::BufferFormat> buffer_formats);
-    ~PlatformProperties();
-    PlatformProperties(const PlatformProperties& other);
-
     // Fuchsia only: set to true when the platforms requires
     // |view_owner_request| field in PlatformWindowInitProperties when creating
     // a window.
@@ -109,9 +100,6 @@ class OZONE_EXPORT OzonePlatform {
     // Determines if the platform requires mojo communication for the IPC.
     // Currently used only by the Ozone/Wayland platform.
     bool requires_mojo = false;
-
-    // Wayland only: carries buffer formats supported by a Wayland server.
-    std::vector<gfx::BufferFormat> supported_buffer_formats;
   };
 
   // Ensures the OzonePlatform instance without doing any initialization.
@@ -144,6 +132,10 @@ class OZONE_EXPORT OzonePlatform {
   // a specific thread, then it needs to do ensure that by itself.
   static void RegisterStartupCallback(
       base::OnceCallback<void(OzonePlatform*)> callback);
+
+  // Returns true if the specified buffer format is supported.
+  virtual bool IsNativePixmapConfigSupported(gfx::BufferFormat format,
+                                             gfx::BufferUsage usage) const;
 
   // Factory getters to override in subclasses. The returned objects will be
   // injected into the appropriate layer at startup. Subclasses should not

--- a/src/ui/ozone/public/ozone_platform.h
+++ b/src/ui/ozone/public/ozone_platform.h
@@ -88,6 +88,7 @@ class OZONE_EXPORT OzonePlatform {
     PlatformProperties(bool needs_request,
                        bool custom_frame_default,
                        bool can_use_system_title_bar,
+                       bool requires_mojo_for_ipc,
                        std::vector<gfx::BufferFormat> buffer_formats);
     ~PlatformProperties();
     PlatformProperties(const PlatformProperties& other);
@@ -104,6 +105,10 @@ class OZONE_EXPORT OzonePlatform {
     // Determine whether switching between system and custom frames is
     // supported.
     bool use_system_title_bar = false;
+
+    // Determines if the platform requires mojo communication for the IPC.
+    // Currently used only by the Ozone/Wayland platform.
+    bool requires_mojo = false;
 
     // Wayland only: carries buffer formats supported by a Wayland server.
     std::vector<gfx::BufferFormat> supported_buffer_formats;


### PR DESCRIPTION
This pull request integrates all the other gpu related patches and enables 
native gpu memory buffer, frame callback, presentation feedback and other features.

Plus, it makes it possible to use system gbm (using minigbm is not possible now until third_party/minigbm is updated, but I don't think we need it at all).

In order to use chromium with a separate gpu process and be able to compile it,
use use_system_minigbm=true gn arg.