### PR TITLE
Backport multimedia hw acceleration patches from ozone-wayland-dev branch

### DIFF
--- a/src/media/gpu/BUILD.gn
+++ b/src/media/gpu/BUILD.gn
@@ -16,6 +16,7 @@ buildflag_header("buildflags") {
     "USE_VAAPI=$use_vaapi",
     "USE_V4L2_CODEC=$use_v4l2_codec",
     "USE_LIBV4L2=$use_v4lplugin",
+    "USE_LINUX_V4L2=$use_linux_v4l2_only",
   ]
 }
 
@@ -23,7 +24,7 @@ if (is_mac) {
   import("//build/config/mac/mac_sdk.gni")
 }
 
-if (is_chromeos && use_v4lplugin) {
+if (use_v4lplugin) {
   action("libv4l2_generate_stubs") {
     extra_header = "v4l2/v4l2_stub_header.fragment"
 
@@ -232,15 +233,19 @@ component("gpu") {
       "v4l2/v4l2_device.h",
       "v4l2/v4l2_image_processor.cc",
       "v4l2/v4l2_image_processor.h",
-      "v4l2/v4l2_jpeg_decode_accelerator.cc",
-      "v4l2/v4l2_jpeg_decode_accelerator.h",
-      "v4l2/v4l2_slice_video_decode_accelerator.cc",
-      "v4l2/v4l2_slice_video_decode_accelerator.h",
       "v4l2/v4l2_video_decode_accelerator.cc",
       "v4l2/v4l2_video_decode_accelerator.h",
       "v4l2/v4l2_video_encode_accelerator.cc",
       "v4l2/v4l2_video_encode_accelerator.h",
     ]
+    if (!use_linux_v4l2_only) {
+      sources += [
+        "v4l2_jpeg_decode_accelerator.cc",
+        "v4l2_jpeg_decode_accelerator.h",
+        "v4l2_slice_video_decode_accelerator.cc",
+        "v4l2_slice_video_decode_accelerator.h",
+      ]
+    }
     libs = [
       "EGL",
       "GLESv2",

--- a/src/media/gpu/args.gni
+++ b/src/media/gpu/args.gni
@@ -10,6 +10,10 @@ declare_args() {
   # platforms which have v4l2 hardware encoder / decoder.
   use_v4l2_codec = false
 
+  # Indicates that only definitions available in the mainline linux kernel
+  # will be used.
+  use_linux_v4l2_only = false
+
   # Indicates if VA-API-based hardware acceleration is to be used. This
   # is typically the case on x86-based ChromeOS devices.
   use_vaapi = false

--- a/src/media/gpu/gpu_jpeg_decode_accelerator_factory.cc
+++ b/src/media/gpu/gpu_jpeg_decode_accelerator_factory.cc
@@ -13,7 +13,8 @@
 #include "media/gpu/buildflags.h"
 #include "media/gpu/fake_jpeg_decode_accelerator.h"
 
-#if BUILDFLAG(USE_V4L2_CODEC) && defined(ARCH_CPU_ARM_FAMILY)
+#if BUILDFLAG(USE_V4L2_CODEC) && defined(ARCH_CPU_ARM_FAMILY) && \
+    !BUILDFLAG(USE_LINUX_V4L2)
 #define USE_V4L2_JDA
 #endif
 

--- a/src/media/gpu/gpu_video_decode_accelerator_factory.cc
+++ b/src/media/gpu/gpu_video_decode_accelerator_factory.cc
@@ -98,7 +98,9 @@ GpuVideoDecodeAcceleratorFactory::GetDecoderCapabilities(
   vda_profiles = V4L2VideoDecodeAccelerator::GetSupportedProfiles();
   GpuVideoAcceleratorUtil::InsertUniqueDecodeProfiles(
       vda_profiles, &capabilities.supported_profiles);
+#if !BUILDFLAG(USE_LINUX_V4L2)
   vda_profiles = V4L2SliceVideoDecodeAccelerator::GetSupportedProfiles();
+#endif
   GpuVideoAcceleratorUtil::InsertUniqueDecodeProfiles(
       vda_profiles, &capabilities.supported_profiles);
 #endif
@@ -144,7 +146,9 @@ GpuVideoDecodeAcceleratorFactory::CreateVDA(
 #endif
 #if BUILDFLAG(USE_V4L2_CODEC)
     &GpuVideoDecodeAcceleratorFactory::CreateV4L2VDA,
+#if !BUILDFLAG(USE_LINUX_V4L2)
     &GpuVideoDecodeAcceleratorFactory::CreateV4L2SVDA,
+#endif
 #endif
 #if BUILDFLAG(USE_VAAPI)
     &GpuVideoDecodeAcceleratorFactory::CreateVaapiVDA,
@@ -199,6 +203,7 @@ GpuVideoDecodeAcceleratorFactory::CreateV4L2VDA(
   return decoder;
 }
 
+#if !BUILDFLAG(USE_LINUX_V4L2)
 std::unique_ptr<VideoDecodeAccelerator>
 GpuVideoDecodeAcceleratorFactory::CreateV4L2SVDA(
     const gpu::GpuDriverBugWorkarounds& workarounds,
@@ -213,6 +218,7 @@ GpuVideoDecodeAcceleratorFactory::CreateV4L2SVDA(
   }
   return decoder;
 }
+#endif
 #endif
 
 #if BUILDFLAG(USE_VAAPI)

--- a/src/media/gpu/gpu_video_decode_accelerator_factory.h
+++ b/src/media/gpu/gpu_video_decode_accelerator_factory.h
@@ -108,10 +108,12 @@ class MEDIA_GPU_EXPORT GpuVideoDecodeAcceleratorFactory {
       const gpu::GpuDriverBugWorkarounds& workarounds,
       const gpu::GpuPreferences& gpu_preferences,
       MediaLog* media_log) const;
+#if !BUILDFLAG(USE_LINUX_V4L2)
   std::unique_ptr<VideoDecodeAccelerator> CreateV4L2SVDA(
       const gpu::GpuDriverBugWorkarounds& workarounds,
       const gpu::GpuPreferences& gpu_preferences,
       MediaLog* media_log) const;
+#endif
 #endif
 #if BUILDFLAG(USE_VAAPI)
   std::unique_ptr<VideoDecodeAccelerator> CreateVaapiVDA(

--- a/src/media/gpu/v4l2/generic_v4l2_device.cc
+++ b/src/media/gpu/v4l2/generic_v4l2_device.cc
@@ -102,10 +102,20 @@ void* GenericV4L2Device::Mmap(void* addr,
                               int flags,
                               unsigned int offset) {
   DCHECK(device_fd_.is_valid());
+#if BUILDFLAG(USE_LIBV4L2)
+  if (use_libv4l2_)
+    return v4l2_mmap(addr, len, prot, flags, device_fd_.get(), offset);
+#endif
   return mmap(addr, len, prot, flags, device_fd_.get(), offset);
 }
 
 void GenericV4L2Device::Munmap(void* addr, unsigned int len) {
+#if BUILDFLAG(USE_LIBV4L2)
+  if (use_libv4l2_) {
+    v4l2_munmap(addr, len);
+    return;
+  }
+#endif
   munmap(addr, len);
 }
 

--- a/src/media/gpu/v4l2/generic_v4l2_device.cc
+++ b/src/media/gpu/v4l2/generic_v4l2_device.cc
@@ -474,9 +474,13 @@ bool GenericV4L2Device::OpenDevicePath(const std::string& path, Type type) {
     return false;
 
 #if BUILDFLAG(USE_LIBV4L2)
+#if BUILDFLAG(USE_LINUX_V4L2)
+  if (
+#else
   if (type == Type::kEncoder &&
+#endif
       HANDLE_EINTR(v4l2_fd_open(device_fd_.get(), V4L2_DISABLE_CONVERSION)) !=
-          -1) {
+      -1) {
     VLOGF(2) << "Using libv4l2 for " << path;
     use_libv4l2_ = true;
   }

--- a/src/media/gpu/v4l2/v4l2.sig
+++ b/src/media/gpu/v4l2/v4l2.sig
@@ -8,3 +8,5 @@
 LIBV4L_PUBLIC int v4l2_close(int fd);
 LIBV4L_PUBLIC int v4l2_ioctl(int fd, unsigned long int request, ...);
 LIBV4L_PUBLIC int v4l2_fd_open(int fd, int v4l2_flags);
+LIBV4L_PUBLIC void *v4l2_mmap(void *start, size_t length, int prot, int flags, int fd, int64_t offset);
+LIBV4L_PUBLIC int v4l2_munmap(void *_start, size_t length);

--- a/src/media/gpu/v4l2/v4l2_video_decode_accelerator.cc
+++ b/src/media/gpu/v4l2/v4l2_video_decode_accelerator.cc
@@ -23,6 +23,7 @@
 #include "base/trace_event/trace_event.h"
 #include "build/build_config.h"
 #include "media/base/media_switches.h"
+#include "media/gpu/buildflags.h"
 #include "media/gpu/shared_memory_region.h"
 #include "media/video/h264_parser.h"
 #include "ui/gfx/geometry/rect.h"
@@ -64,7 +65,10 @@ namespace media {
 
 // static
 const uint32_t V4L2VideoDecodeAccelerator::supported_input_fourccs_[] = {
-    V4L2_PIX_FMT_H264, V4L2_PIX_FMT_VP8, V4L2_PIX_FMT_VP9,
+    V4L2_PIX_FMT_H264, V4L2_PIX_FMT_VP8,
+#if !BUILDFLAG(USE_LINUX_V4L2)
+    V4L2_PIX_FMT_VP9,
+#endif
 };
 
 struct V4L2VideoDecodeAccelerator::BitstreamBufferRef {

--- a/src/media/gpu/v4l2/v4l2_video_decode_accelerator.cc
+++ b/src/media/gpu/v4l2/v4l2_video_decode_accelerator.cc
@@ -66,7 +66,7 @@ namespace media {
 // static
 const uint32_t V4L2VideoDecodeAccelerator::supported_input_fourccs_[] = {
     V4L2_PIX_FMT_H264, V4L2_PIX_FMT_VP8,
-#if !BUILDFLAG(USE_LINUX_V4L2)
+#if !defined(USE_LINUX_V4L2)
     V4L2_PIX_FMT_VP9,
 #endif
 };


### PR DESCRIPTION
These two patches enable hw accelerated video decoding on Renesas board using gstreamer and v4l2 device. In order to use it, one must use the following args -

```
use_v4l2_codec=true
use_linux_v4l2_only=true
use_v4lplugin=true
```

And refer to the following manual - https://github.com/igel-oss/meta-browser-hwdecode
