### PR TITLE
Clipboard

### DIFF
--- a/src/ui/base/BUILD.gn
+++ b/src/ui/base/BUILD.gn
@@ -648,12 +648,21 @@ component("base") {
 
   if (use_aura) {
     # Aura clipboard.
-    if (use_x11 && is_desktop_linux) {
-      sources += [
-        "clipboard/clipboard_aura_linux.cc",
-        "clipboard/clipboard_aurax11.cc",
-        "clipboard/clipboard_aurax11.h",
-      ]
+    if (is_desktop_linux) {
+      if (use_x11 || use_ozone) {
+        sources += [ "clipboard/clipboard_aura_linux.cc" ]
+      }
+      if (use_ozone) {
+        sources += [
+          "clipboard/clipboard_ozone.cc",
+          "clipboard/clipboard_ozone.h",
+        ]
+      } else if (use_x11) {
+        sources += [
+          "clipboard/clipboard_aurax11.cc",
+          "clipboard/clipboard_aurax11.h",
+        ]
+      }
     } else if (!is_win) {
       # This file is used for all non-X11, non-Windows aura Builds.
       sources += [

--- a/src/ui/base/BUILD.gn
+++ b/src/ui/base/BUILD.gn
@@ -650,6 +650,7 @@ component("base") {
     # Aura clipboard.
     if (use_x11 && is_desktop_linux) {
       sources += [
+        "clipboard/clipboard_aura_linux.cc",
         "clipboard/clipboard_aurax11.cc",
         "clipboard/clipboard_aurax11.h",
       ]

--- a/src/ui/base/clipboard/DEPS
+++ b/src/ui/base/clipboard/DEPS
@@ -1,4 +1,5 @@
 include_rules = [
   "+jni",
   "+third_party/mozilla",
+  "+ui/ozone/public/clipboard_delegate.h",
 ]

--- a/src/ui/base/clipboard/clipboard.h
+++ b/src/ui/base/clipboard/clipboard.h
@@ -16,6 +16,7 @@
 #include "base/containers/flat_map.h"
 #include "base/lazy_instance.h"
 #include "base/macros.h"
+#include "base/no_destructor.h"
 #include "base/process/process.h"
 #include "base/strings/string16.h"
 #include "base/synchronization/lock.h"
@@ -83,6 +84,7 @@ class UI_BASE_EXPORT Clipboard : public base::ThreadChecker {
 
    private:
     friend class Clipboard;
+    friend class base::NoDestructor<FormatType>;
 
     // Platform-specific glue used internally by the Clipboard class. Each
     // plaform should define,at least one of each of the following:

--- a/src/ui/base/clipboard/clipboard_aura_linux.cc
+++ b/src/ui/base/clipboard/clipboard_aura_linux.cc
@@ -1,0 +1,118 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ui/base/clipboard/clipboard.h"
+
+namespace ui {
+
+constexpr char kMimeTypeFilename[] = "chromium/filename";
+
+Clipboard::FormatType::FormatType() {}
+
+Clipboard::FormatType::FormatType(const std::string& native_format)
+    : data_(native_format) {}
+
+Clipboard::FormatType::~FormatType() {}
+
+std::string Clipboard::FormatType::Serialize() const {
+  return data_;
+}
+
+// static
+Clipboard::FormatType Clipboard::FormatType::Deserialize(
+    const std::string& serialization) {
+  return FormatType(serialization);
+}
+
+bool Clipboard::FormatType::operator<(const FormatType& other) const {
+  return data_ < other.data_;
+}
+
+bool Clipboard::FormatType::Equals(const FormatType& other) const {
+  return data_ == other.data_;
+}
+
+// Various predefined FormatTypes.
+// static
+Clipboard::FormatType Clipboard::GetFormatType(
+    const std::string& format_string) {
+  return FormatType::Deserialize(format_string);
+}
+
+// static
+const Clipboard::FormatType& Clipboard::GetUrlFormatType() {
+  static base::NoDestructor<FormatType> type(kMimeTypeURIList);
+  return *type;
+}
+
+// static
+const Clipboard::FormatType& Clipboard::GetUrlWFormatType() {
+  return GetUrlFormatType();
+}
+
+// static
+const Clipboard::FormatType& Clipboard::GetMozUrlFormatType() {
+  static base::NoDestructor<FormatType> type(kMimeTypeMozillaURL);
+  return *type;
+}
+
+// static
+const Clipboard::FormatType& Clipboard::GetPlainTextFormatType() {
+  static base::NoDestructor<FormatType> type(kMimeTypeText);
+  return *type;
+}
+
+// static
+const Clipboard::FormatType& Clipboard::GetPlainTextWFormatType() {
+  return GetPlainTextFormatType();
+}
+
+// static
+const Clipboard::FormatType& Clipboard::GetFilenameFormatType() {
+  static base::NoDestructor<FormatType> type(kMimeTypeFilename);
+  return *type;
+}
+
+// static
+const Clipboard::FormatType& Clipboard::GetFilenameWFormatType() {
+  return Clipboard::GetFilenameFormatType();
+}
+
+// static
+const Clipboard::FormatType& Clipboard::GetHtmlFormatType() {
+  static base::NoDestructor<FormatType> type(kMimeTypeHTML);
+  return *type;
+}
+
+// static
+const Clipboard::FormatType& Clipboard::GetRtfFormatType() {
+  static base::NoDestructor<FormatType> type(kMimeTypeRTF);
+  return *type;
+}
+
+// static
+const Clipboard::FormatType& Clipboard::GetBitmapFormatType() {
+  static base::NoDestructor<FormatType> type(kMimeTypePNG);
+  return *type;
+}
+
+// static
+const Clipboard::FormatType& Clipboard::GetWebKitSmartPasteFormatType() {
+  static base::NoDestructor<FormatType> type(kMimeTypeWebkitSmartPaste);
+  return *type;
+}
+
+// static
+const Clipboard::FormatType& Clipboard::GetWebCustomDataFormatType() {
+  static base::NoDestructor<FormatType> type(kMimeTypeWebCustomData);
+  return *type;
+}
+
+// static
+const Clipboard::FormatType& Clipboard::GetPepperCustomDataFormatType() {
+  static base::NoDestructor<FormatType> type(kMimeTypePepperCustomData);
+  return *type;
+}
+
+}  // namespace ui

--- a/src/ui/base/clipboard/clipboard_aurax11.cc
+++ b/src/ui/base/clipboard/clipboard_aurax11.cc
@@ -41,7 +41,6 @@ namespace {
 
 const char kClipboard[] = "CLIPBOARD";
 const char kClipboardManager[] = "CLIPBOARD_MANAGER";
-const char kMimeTypeFilename[] = "chromium/filename";
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -167,41 +166,6 @@ bool TargetList::ContainsAtom(::Atom atom) const {
 }
 
 }  // namespace
-
-///////////////////////////////////////////////////////////////////////////////
-
-// I would love for the FormatType to really be a wrapper around an X11 ::Atom,
-// but there are a few problems. Chromeos unit tests spawn a new X11 server for
-// each test, so Atom numeric values don't persist across tests. We could still
-// maybe deal with that if we didn't have static accessor methods everywhere.
-
-Clipboard::FormatType::FormatType() {
-}
-
-Clipboard::FormatType::FormatType(const std::string& native_format)
-    : data_(native_format) {
-}
-
-Clipboard::FormatType::~FormatType() {
-}
-
-std::string Clipboard::FormatType::Serialize() const {
-  return data_;
-}
-
-// static
-Clipboard::FormatType Clipboard::FormatType::Deserialize(
-    const std::string& serialization) {
-  return FormatType(serialization);
-}
-
-bool Clipboard::FormatType::operator<(const FormatType& other) const {
-  return data_ < other.data_;
-}
-
-bool Clipboard::FormatType::Equals(const FormatType& other) const {
-  return data_ == other.data_;
-}
 
 ///////////////////////////////////////////////////////////////////////////////
 // ClipboardAuraX11::AuraX11Details
@@ -545,89 +509,6 @@ uint32_t ClipboardAuraX11::AuraX11Details::DispatchEvent(
   }
 
   return POST_DISPATCH_NONE;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-// Various predefined FormatTypes.
-// static
-Clipboard::FormatType Clipboard::GetFormatType(
-    const std::string& format_string) {
-  return FormatType::Deserialize(format_string);
-}
-
-// static
-const Clipboard::FormatType& Clipboard::GetUrlFormatType() {
-  CR_DEFINE_STATIC_LOCAL(FormatType, type, (kMimeTypeURIList));
-  return type;
-}
-
-// static
-const Clipboard::FormatType& Clipboard::GetUrlWFormatType() {
-  return GetUrlFormatType();
-}
-
-// static
-const Clipboard::FormatType& Clipboard::GetMozUrlFormatType() {
-  CR_DEFINE_STATIC_LOCAL(FormatType, type, (kMimeTypeMozillaURL));
-  return type;
-}
-
-// static
-const Clipboard::FormatType& Clipboard::GetPlainTextFormatType() {
-  CR_DEFINE_STATIC_LOCAL(FormatType, type, (kMimeTypeText));
-  return type;
-}
-
-// static
-const Clipboard::FormatType& Clipboard::GetPlainTextWFormatType() {
-  return GetPlainTextFormatType();
-}
-
-// static
-const Clipboard::FormatType& Clipboard::GetFilenameFormatType() {
-  CR_DEFINE_STATIC_LOCAL(FormatType, type, (kMimeTypeFilename));
-  return type;
-}
-
-// static
-const Clipboard::FormatType& Clipboard::GetFilenameWFormatType() {
-  return Clipboard::GetFilenameFormatType();
-}
-
-// static
-const Clipboard::FormatType& Clipboard::GetHtmlFormatType() {
-  CR_DEFINE_STATIC_LOCAL(FormatType, type, (kMimeTypeHTML));
-  return type;
-}
-
-// static
-const Clipboard::FormatType& Clipboard::GetRtfFormatType() {
-  CR_DEFINE_STATIC_LOCAL(FormatType, type, (kMimeTypeRTF));
-  return type;
-}
-
-// static
-const Clipboard::FormatType& Clipboard::GetBitmapFormatType() {
-  CR_DEFINE_STATIC_LOCAL(FormatType, type, (kMimeTypePNG));
-  return type;
-}
-
-// static
-const Clipboard::FormatType& Clipboard::GetWebKitSmartPasteFormatType() {
-  CR_DEFINE_STATIC_LOCAL(FormatType, type, (kMimeTypeWebkitSmartPaste));
-  return type;
-}
-
-// static
-const Clipboard::FormatType& Clipboard::GetWebCustomDataFormatType() {
-  CR_DEFINE_STATIC_LOCAL(FormatType, type, (kMimeTypeWebCustomData));
-  return type;
-}
-
-// static
-const Clipboard::FormatType& Clipboard::GetPepperCustomDataFormatType() {
-  CR_DEFINE_STATIC_LOCAL(FormatType, type, (kMimeTypePepperCustomData));
-  return type;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/ui/base/clipboard/clipboard_ozone.cc
+++ b/src/ui/base/clipboard/clipboard_ozone.cc
@@ -1,0 +1,411 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ui/base/clipboard/clipboard_ozone.h"
+
+#include <memory>
+
+#include "base/bind.h"
+#include "base/macros.h"
+#include "base/memory/weak_ptr.h"
+#include "base/run_loop.h"
+#include "base/strings/utf_string_conversions.h"
+#include "base/timer/timer.h"
+#include "third_party/skia/include/core/SkBitmap.h"
+#include "ui/base/clipboard/custom_data_helper.h"
+#include "ui/gfx/codec/png_codec.h"
+#include "ui/ozone/public/clipboard_delegate.h"
+
+namespace ui {
+
+// A helper class, which uses a request pattern to asynchronously communicate
+// with the ozone::ClipboardDelegate and fetch clipboard data with mimes
+// specified.
+class ClipboardOzone::AsyncClipboardOzone {
+ public:
+  AsyncClipboardOzone()
+      : delegate_(ClipboardDelegate::GetInstance()), weak_factory_(this) {}
+
+  ~AsyncClipboardOzone() = default;
+
+  std::vector<uint8_t> ReadClipboardDataAndWait(ClipboardType type,
+                                                const std::string& mime_type) {
+    // TODO(tonikitoo): add selection support.
+    if (type == ClipboardType::CLIPBOARD_TYPE_SELECTION)
+      return std::vector<uint8_t>();
+
+    // We can use a fastpath if we are the owner of the selection.
+    if (delegate_->IsSelectionOwner()) {
+      return offered_data_.find(mime_type) != offered_data_.end()
+                 ? offered_data_[mime_type]
+                 : std::vector<uint8_t>();
+    }
+
+    std::unique_ptr<Request> request =
+        std::make_unique<Request>(RequestType::READ);
+    request->requested_mime_type = mime_type;
+    ProcessRequestAndWaitForResult(request.get());
+    return !request->data_map.empty() ? request->data_map[mime_type]
+                                      : std::vector<uint8_t>();
+  }
+
+  std::vector<std::string> RequestMimeTypes() {
+    std::unique_ptr<Request> request =
+        std::make_unique<Request>(RequestType::GET_MIME);
+    ProcessRequestAndWaitForResult(request.get());
+    return std::move(request->mime_types);
+  }
+
+  void OfferData() {
+    std::unique_ptr<Request> request =
+        std::make_unique<Request>(RequestType::OFFER);
+    request->data_map = offered_data_;
+    ProcessRequestAndWaitForResult(request.get());
+
+    ++sequence_number_;
+  }
+
+  void InsertData(std::vector<uint8_t> data, const std::string& mime_type) {
+    DCHECK(offered_data_.find(mime_type) == offered_data_.end());
+    offered_data_[mime_type] = std::move(data);
+  }
+
+  void ClearOfferedData() { offered_data_.clear(); }
+
+  uint64_t sequence_number() const { return sequence_number_; }
+
+ private:
+  enum class RequestType {
+    READ = 0,
+    OFFER = 1,
+    GET_MIME = 2,
+  };
+
+  // A structure, which holds request data to process inquiries from
+  // the ClipboardOzone.
+  struct Request {
+    explicit Request(RequestType type) : current_type(type) {}
+    ~Request() = default;
+
+    // Describes the type of the request.
+    RequestType current_type;
+
+    // A closure that is used to signal the request is processed.
+    base::OnceClosure request_closure;
+
+    // A data map that stores the result data or offers clipboard data.
+    ClipboardDelegate::DataMap data_map;
+
+    // A requested mime type of the current request.
+    std::string requested_mime_type;
+
+    // A vector of mime types returned as a result to a request to get available
+    // mime types.
+    std::vector<std::string> mime_types;
+
+    // The time when the request should be aborted.
+    base::TimeTicks timeout;
+  };
+
+  void ProcessRequestAndWaitForResult(Request* request) {
+    DCHECK(!abort_timer_.IsRunning());
+    DCHECK(!pending_request_);
+
+    base::RunLoop run_loop(base::RunLoop::Type::kNestableTasksAllowed);
+    base::TimeTicks timeout =
+        base::TimeTicks::Now() + base::TimeDelta::FromMilliseconds(1000);
+    request->request_closure = run_loop.QuitClosure();
+    request->timeout = timeout;
+
+    pending_request_ = request;
+    switch (pending_request_->current_type) {
+      case (RequestType::READ):
+        ProcessReadRequest(request);
+        break;
+      case (RequestType::OFFER):
+        ProcessOfferRequest(request);
+        break;
+      case (RequestType::GET_MIME):
+        ProcessGetMimeRequest(request);
+        break;
+      default:
+        NOTREACHED();
+        break;
+    }
+
+    if (!pending_request_)
+      return;
+    abort_timer_.Start(FROM_HERE, base::TimeDelta::FromMilliseconds(100), this,
+                       &AsyncClipboardOzone::AbortStaledRequest);
+    run_loop.Run();
+  }
+
+  void AbortStaledRequest() {
+    base::TimeTicks now = base::TimeTicks::Now();
+    if (pending_request_ && pending_request_->timeout >= now)
+      std::move(pending_request_->request_closure).Run();
+  }
+
+  void ProcessReadRequest(Request* request) {
+    auto callback = base::BindOnce(&AsyncClipboardOzone::OnTextRead,
+                                   weak_factory_.GetWeakPtr());
+    DCHECK(delegate_);
+    delegate_->RequestClipboardData(request->requested_mime_type,
+                                    &request->data_map, std::move(callback));
+  }
+
+  void ProcessOfferRequest(Request* request) {
+    auto callback = base::BindOnce(&AsyncClipboardOzone::OnOfferDone,
+                                   weak_factory_.GetWeakPtr());
+    DCHECK(delegate_);
+    delegate_->OfferClipboardData(request->data_map, std::move(callback));
+  }
+
+  void ProcessGetMimeRequest(Request* request) {
+    auto callback = base::BindOnce(&AsyncClipboardOzone::OnGotMimeTypes,
+                                   weak_factory_.GetWeakPtr());
+    DCHECK(delegate_);
+    delegate_->GetAvailableMimeTypes(std::move(callback));
+  }
+
+  void OnTextRead(const base::Optional<std::vector<uint8_t>>& data) {
+    CompleteRequest();
+  }
+
+  void OnOfferDone() { CompleteRequest(); }
+
+  void OnGotMimeTypes(const std::vector<std::string>& mime_types) {
+    pending_request_->mime_types = std::move(mime_types);
+    CompleteRequest();
+  }
+
+  void CompleteRequest() {
+    abort_timer_.Stop();
+    auto closure = std::move(pending_request_->request_closure);
+    pending_request_ = nullptr;
+    std::move(closure).Run();
+  }
+
+  // Cached clipboard data, which is pending to be written. Must be cleared on
+  // every new write to the |delegate_|.
+  ClipboardDelegate::DataMap offered_data_;
+
+  // A current pending request being processed.
+  Request* pending_request_ = nullptr;
+
+  // Aborts |pending_request| after Request::timeout.
+  base::RepeatingTimer abort_timer_;
+
+  // Provides communication to a system clipboard under ozone level.
+  ClipboardDelegate* delegate_ = nullptr;
+
+  uint64_t sequence_number_ = 0;
+
+  base::WeakPtrFactory<AsyncClipboardOzone> weak_factory_;
+
+  DISALLOW_COPY_AND_ASSIGN(AsyncClipboardOzone);
+};
+
+// Clipboard factory method.
+Clipboard* Clipboard::Create() {
+  return new ClipboardOzone;
+}
+
+// ClipboardOzone implementation.
+ClipboardOzone::ClipboardOzone() {
+  async_clipboard_ozone_ =
+      std::make_unique<ClipboardOzone::AsyncClipboardOzone>();
+}
+
+ClipboardOzone::~ClipboardOzone() = default;
+
+void ClipboardOzone::OnPreShutdown() {}
+
+uint64_t ClipboardOzone::GetSequenceNumber(ClipboardType type) const {
+  return async_clipboard_ozone_->sequence_number();
+}
+
+bool ClipboardOzone::IsFormatAvailable(const FormatType& format,
+                                       ClipboardType type) const {
+  DCHECK(CalledOnValidThread());
+  // TODO(tonikitoo): add selection support.
+  if (type == ClipboardType::CLIPBOARD_TYPE_SELECTION)
+    return false;
+
+  auto available_types = async_clipboard_ozone_->RequestMimeTypes();
+  for (auto mime_type : available_types) {
+    if (format.ToString() == mime_type) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void ClipboardOzone::Clear(ClipboardType type) {
+  async_clipboard_ozone_->ClearOfferedData();
+  async_clipboard_ozone_->OfferData();
+}
+
+void ClipboardOzone::ReadAvailableTypes(ClipboardType type,
+                                        std::vector<base::string16>* types,
+                                        bool* contains_filenames) const {
+  DCHECK(CalledOnValidThread());
+  types->clear();
+
+  // TODO(tonikitoo): add selection support.
+  if (type == ClipboardType::CLIPBOARD_TYPE_SELECTION)
+    return;
+
+  auto available_types = async_clipboard_ozone_->RequestMimeTypes();
+  for (auto mime_type : available_types)
+    types->push_back(base::UTF8ToUTF16(mime_type));
+}
+
+void ClipboardOzone::ReadText(ClipboardType type,
+                              base::string16* result) const {
+  DCHECK(CalledOnValidThread());
+
+  auto clipboard_data =
+      async_clipboard_ozone_->ReadClipboardDataAndWait(type, kMimeTypeText);
+  *result = base::UTF8ToUTF16(
+      std::string(clipboard_data.begin(), clipboard_data.end()));
+}
+
+void ClipboardOzone::ReadAsciiText(ClipboardType type,
+                                   std::string* result) const {
+  DCHECK(CalledOnValidThread());
+  auto clipboard_data =
+      async_clipboard_ozone_->ReadClipboardDataAndWait(type, kMimeTypeText);
+  result->assign(clipboard_data.begin(), clipboard_data.end());
+}
+
+void ClipboardOzone::ReadHTML(ClipboardType type,
+                              base::string16* markup,
+                              std::string* src_url,
+                              uint32_t* fragment_start,
+                              uint32_t* fragment_end) const {
+  DCHECK(CalledOnValidThread());
+  markup->clear();
+  if (src_url)
+    src_url->clear();
+  *fragment_start = 0;
+  *fragment_end = 0;
+
+  auto clipboard_data =
+      async_clipboard_ozone_->ReadClipboardDataAndWait(type, kMimeTypeHTML);
+  *markup = base::UTF8ToUTF16(
+      std::string(clipboard_data.begin(), clipboard_data.end()));
+  DCHECK(markup->length() <= std::numeric_limits<uint32_t>::max());
+  *fragment_end = static_cast<uint32_t>(markup->length());
+}
+
+void ClipboardOzone::ReadRTF(ClipboardType type, std::string* result) const {
+  DCHECK(CalledOnValidThread());
+  auto clipboard_data =
+      async_clipboard_ozone_->ReadClipboardDataAndWait(type, kMimeTypeRTF);
+  result->assign(clipboard_data.begin(), clipboard_data.end());
+}
+
+SkBitmap ClipboardOzone::ReadImage(ClipboardType type) const {
+  DCHECK(CalledOnValidThread());
+  auto clipboard_data =
+      async_clipboard_ozone_->ReadClipboardDataAndWait(type, kMimeTypePNG);
+  SkBitmap bitmap;
+  if (gfx::PNGCodec::Decode(&clipboard_data.front(), clipboard_data.size(),
+                            &bitmap))
+    return SkBitmap(bitmap);
+  return SkBitmap();
+}
+
+void ClipboardOzone::ReadCustomData(ClipboardType clipboard_type,
+                                    const base::string16& type,
+                                    base::string16* result) const {
+  DCHECK(CalledOnValidThread());
+  auto custom_data = async_clipboard_ozone_->ReadClipboardDataAndWait(
+      clipboard_type, kMimeTypeWebCustomData);
+  ui::ReadCustomDataForType(&custom_data.front(), custom_data.size(), type,
+                            result);
+}
+
+void ClipboardOzone::ReadBookmark(base::string16* title,
+                                  std::string* url) const {
+  DCHECK(CalledOnValidThread());
+  // TODO(msisov): This was left NOTIMPLEMENTED() in all the Linux platforms.
+  NOTIMPLEMENTED();
+}
+
+void ClipboardOzone::ReadData(const FormatType& format,
+                              std::string* result) const {
+  DCHECK(CalledOnValidThread());
+  auto clipboard_data = async_clipboard_ozone_->ReadClipboardDataAndWait(
+      ClipboardType::CLIPBOARD_TYPE_COPY_PASTE, format.ToString());
+  result->assign(clipboard_data.begin(), clipboard_data.end());
+}
+
+void ClipboardOzone::WriteObjects(ClipboardType type,
+                                  const ObjectMap& objects) {
+  DCHECK(CalledOnValidThread());
+  if (type == ClipboardType::CLIPBOARD_TYPE_COPY_PASTE) {
+    async_clipboard_ozone_->ClearOfferedData();
+
+    for (const auto& object : objects)
+      DispatchObject(static_cast<ObjectType>(object.first), object.second);
+
+    async_clipboard_ozone_->OfferData();
+  }
+}
+
+void ClipboardOzone::WriteText(const char* text_data, size_t text_len) {
+  std::vector<uint8_t> data(text_data, text_data + text_len);
+  async_clipboard_ozone_->InsertData(std::move(data), kMimeTypeText);
+}
+
+void ClipboardOzone::WriteHTML(const char* markup_data,
+                               size_t markup_len,
+                               const char* url_data,
+                               size_t url_len) {
+  std::vector<uint8_t> data(markup_data, markup_data + markup_len);
+  async_clipboard_ozone_->InsertData(std::move(data), kMimeTypeHTML);
+}
+
+void ClipboardOzone::WriteRTF(const char* rtf_data, size_t data_len) {
+  std::vector<uint8_t> data(rtf_data, rtf_data + data_len);
+  async_clipboard_ozone_->InsertData(std::move(data), kMimeTypeRTF);
+}
+
+void ClipboardOzone::WriteBookmark(const char* title_data,
+                                   size_t title_len,
+                                   const char* url_data,
+                                   size_t url_len) {
+  // Writes a Mozilla url (UTF16: URL, newline, title)
+  base::string16 bookmark =
+      base::UTF8ToUTF16(base::StringPiece(url_data, url_len)) +
+      base::ASCIIToUTF16("\n") +
+      base::UTF8ToUTF16(base::StringPiece(title_data, title_len));
+
+  std::vector<uint8_t> data(
+      reinterpret_cast<const uint8_t*>(bookmark.data()),
+      reinterpret_cast<const uint8_t*>(bookmark.data() + bookmark.size()));
+  async_clipboard_ozone_->InsertData(std::move(data), kMimeTypeMozillaURL);
+}
+
+void ClipboardOzone::WriteWebSmartPaste() {
+  async_clipboard_ozone_->InsertData(std::vector<uint8_t>(),
+                                     kMimeTypeWebkitSmartPaste);
+}
+
+void ClipboardOzone::WriteBitmap(const SkBitmap& bitmap) {
+  std::vector<unsigned char> output;
+  if (gfx::PNGCodec::FastEncodeBGRASkBitmap(bitmap, false, &output))
+    async_clipboard_ozone_->InsertData(std::move(output), kMimeTypePNG);
+}
+
+void ClipboardOzone::WriteData(const FormatType& format,
+                               const char* data_data,
+                               size_t data_len) {
+  std::vector<uint8_t> data(data_data, data_data + data_len);
+  async_clipboard_ozone_->InsertData(data, format.ToString());
+}
+
+}  // namespace ui

--- a/src/ui/base/clipboard/clipboard_ozone.h
+++ b/src/ui/base/clipboard/clipboard_ozone.h
@@ -1,0 +1,72 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef UI_BASE_CLIPBOARD_CLIPBOARD_OZONE_H_
+#define UI_BASE_CLIPBOARD_CLIPBOARD_OZONE_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "base/macros.h"
+#include "ui/base/clipboard/clipboard.h"
+
+namespace ui {
+
+class ClipboardOzone : public Clipboard {
+ private:
+  friend class Clipboard;
+
+  ClipboardOzone();
+  ~ClipboardOzone() override;
+
+  // Clipboard overrides:
+  void OnPreShutdown() override;
+  uint64_t GetSequenceNumber(ClipboardType type) const override;
+  bool IsFormatAvailable(const FormatType& format,
+                         ClipboardType type) const override;
+  void Clear(ClipboardType type) override;
+  void ReadAvailableTypes(ClipboardType type,
+                          std::vector<base::string16>* types,
+                          bool* contains_filenames) const override;
+  void ReadText(ClipboardType type, base::string16* result) const override;
+  void ReadAsciiText(ClipboardType type, std::string* result) const override;
+  void ReadHTML(ClipboardType type,
+                base::string16* markup,
+                std::string* src_url,
+                uint32_t* fragment_start,
+                uint32_t* fragment_end) const override;
+  void ReadRTF(ClipboardType type, std::string* result) const override;
+  SkBitmap ReadImage(ClipboardType type) const override;
+  void ReadCustomData(ClipboardType clipboard_type,
+                      const base::string16& type,
+                      base::string16* result) const override;
+  void ReadBookmark(base::string16* title, std::string* url) const override;
+  void ReadData(const FormatType& format, std::string* result) const override;
+  void WriteObjects(ClipboardType type, const ObjectMap& objects) override;
+  void WriteText(const char* text_data, size_t text_len) override;
+  void WriteHTML(const char* markup_data,
+                 size_t markup_len,
+                 const char* url_data,
+                 size_t url_len) override;
+  void WriteRTF(const char* rtf_data, size_t data_len) override;
+  void WriteBookmark(const char* title_data,
+                     size_t title_len,
+                     const char* url_data,
+                     size_t url_len) override;
+  void WriteWebSmartPaste() override;
+  void WriteBitmap(const SkBitmap& bitmap) override;
+  void WriteData(const FormatType& format,
+                 const char* data_data,
+                 size_t data_len) override;
+
+  class AsyncClipboardOzone;
+
+  std::unique_ptr<AsyncClipboardOzone> async_clipboard_ozone_;
+
+  DISALLOW_COPY_AND_ASSIGN(ClipboardOzone);
+};
+
+}  // namespace ui
+
+#endif  // UI_BASE_CLIPBOARD_CLIPBOARD_OZONE_H_

--- a/src/ui/base/clipboard/clipboard_test_template.h
+++ b/src/ui/base/clipboard/clipboard_test_template.h
@@ -185,8 +185,8 @@ TYPED_TEST(ClipboardTest, RTFTest) {
   EXPECT_EQ(rtf, result);
 }
 
-// TODO(dnicoara) Enable test once Ozone implements clipboard support:
-// crbug.com/361707
+// TODO(msisov, tonikitoo): Enable test once ClipboardOzone implements
+// selection support. https://crbug.com/911992
 #if defined(OS_LINUX) && !defined(OS_CHROMEOS) && !defined(USE_OZONE)
 TYPED_TEST(ClipboardTest, MultipleBufferTest) {
   base::string16 text(ASCIIToUTF16("Standard")), text_result;
@@ -372,8 +372,10 @@ TYPED_TEST(ClipboardTest, URLTest) {
   this->clipboard().ReadAsciiText(CLIPBOARD_TYPE_COPY_PASTE, &ascii_text);
   EXPECT_EQ(UTF16ToUTF8(url), ascii_text);
 
+// TODO(tonikitoo, msisov): enable back for ClipboardOzone implements
+// selection support. https://crbug.com/911992
 #if defined(OS_POSIX) && !defined(OS_MACOSX) && !defined(OS_ANDROID) && \
-    !defined(OS_CHROMEOS)
+    !defined(OS_CHROMEOS) && !defined(USE_OZONE)
   if (!this->IsMusTest()) {
     ascii_text.clear();
     this->clipboard().ReadAsciiText(CLIPBOARD_TYPE_SELECTION, &ascii_text);

--- a/src/ui/ozone/BUILD.gn
+++ b/src/ui/ozone/BUILD.gn
@@ -5,10 +5,10 @@
 import("//build/config/jumbo.gni")
 import("//build/config/ui.gni")
 import("//gpu/vulkan/features.gni")
+import("//neva/neva.gni")
 import("//ui/ozone/ozone.gni")
 import("//ui/ozone/ozone_extra.gni")
 import("//testing/test.gni")
-import("//neva/neva.gni")
 
 assert(use_ozone)
 
@@ -69,9 +69,12 @@ constructor_list_cc_file = "$target_gen_dir/constructor_list.cc"
 jumbo_component("ozone_base") {
   sources = [
     "ozone_base_export.h",
+    "public/clipboard_delegate.cc",
     "public/clipboard_delegate.h",
     "public/cursor_factory_ozone.cc",
     "public/cursor_factory_ozone.h",
+    "public/fake_clipboard_delegate.cc",
+    "public/fake_clipboard_delegate.h",
     "public/gl_ozone.h",
     "public/gpu_platform_support.cc",
     "public/gpu_platform_support.h",

--- a/src/ui/ozone/public/clipboard_delegate.cc
+++ b/src/ui/ozone/public/clipboard_delegate.cc
@@ -1,0 +1,42 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ui/ozone/public/clipboard_delegate.h"
+
+#include "ui/ozone/public/fake_clipboard_delegate.h"
+
+namespace ui {
+
+namespace {
+
+ClipboardDelegate* g_delegate_instance = nullptr;
+
+}  // namespace
+
+ClipboardDelegate::ClipboardDelegate() {
+  DCHECK(!g_delegate_instance)
+      << "Only one instance of ClipboardDelegate is allowed.";
+  g_delegate_instance = this;
+}
+
+ClipboardDelegate::~ClipboardDelegate() {
+  DCHECK_EQ(g_delegate_instance, this);
+  g_delegate_instance = nullptr;
+}
+
+ClipboardDelegate* ClipboardDelegate::GetInstance() {
+  if (!g_delegate_instance) {
+    LOG(ERROR) << "No ClipboardDelegate is available. Falling back to "
+                  "FakeClipboardDelegate. Please note that each Ozone platform "
+                  "must provide own ClipboardDelegate implementations in order "
+                  "to be able to communicate with a system clipboard.";
+    std::unique_ptr<FakeClipboardDelegate> delegate =
+        std::make_unique<FakeClipboardDelegate>();
+    CHECK(g_delegate_instance) << "Unable to create fake clipboard delegate";
+    delegate.release();
+  }
+  return g_delegate_instance;
+}
+
+}  // namespace ui

--- a/src/ui/ozone/public/clipboard_delegate.h
+++ b/src/ui/ozone/public/clipboard_delegate.h
@@ -21,10 +21,15 @@ namespace ui {
 //
 class OZONE_BASE_EXPORT ClipboardDelegate {
  public:
+  ClipboardDelegate();
+  virtual ~ClipboardDelegate();
+
   // DataMap is a map from "mime type" to associated data, whereas
   // the data can be organized differently for each mime type.
   using Data = std::vector<uint8_t>;
   using DataMap = std::unordered_map<std::string, Data>;
+
+  static ClipboardDelegate* GetInstance();
 
   // Offers a given clipboard data 'data_map' to the host system clipboard.
   //

--- a/src/ui/ozone/public/fake_clipboard_delegate.cc
+++ b/src/ui/ozone/public/fake_clipboard_delegate.cc
@@ -1,0 +1,44 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ui/ozone/public/fake_clipboard_delegate.h"
+
+namespace ui {
+
+FakeClipboardDelegate::FakeClipboardDelegate() = default;
+
+FakeClipboardDelegate::~FakeClipboardDelegate() = default;
+
+void FakeClipboardDelegate::OfferClipboardData(const DataMap& data_map,
+                                               OfferDataClosure callback) {
+  offered_data_map_ = data_map;
+  std::move(callback).Run();
+}
+
+void FakeClipboardDelegate::RequestClipboardData(const std::string& mime_type,
+                                                 DataMap* data_map,
+                                                 RequestDataClosure callback) {
+  auto it = offered_data_map_.find(mime_type);
+  if (it == offered_data_map_.end()) {
+    std::move(callback).Run(base::Optional<ClipboardDelegate::Data>());
+    return;
+  }
+  *data_map = offered_data_map_;
+  std::move(callback).Run(std::move(it->second));
+}
+
+void FakeClipboardDelegate::GetAvailableMimeTypes(
+    GetMimeTypesClosure callback) {
+  std::vector<std::string> mime_types;
+  for (const auto& item : offered_data_map_) {
+    mime_types.push_back(item.first);
+  }
+  std::move(callback).Run(std::move(mime_types));
+}
+
+bool FakeClipboardDelegate::IsSelectionOwner() {
+  return !offered_data_map_.empty();
+}
+
+}  // namespace ui

--- a/src/ui/ozone/public/fake_clipboard_delegate.h
+++ b/src/ui/ozone/public/fake_clipboard_delegate.h
@@ -1,0 +1,39 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef UI_OZONE_PUBLIC_FAKE_CLIPBOARD_DELEGATE_H_
+#define UI_OZONE_PUBLIC_FAKE_CLIPBOARD_DELEGATE_H_
+
+#include "base/callback.h"
+#include "base/macros.h"
+#include "base/memory/scoped_refptr.h"
+#include "ui/ozone/public/clipboard_delegate.h"
+
+namespace ui {
+
+// Fake clipboard delegate, which just stores offered clipboard data and sends
+// it back on requests. It's created automatically if ozone platforms do not
+// implement and create ClipboardDelegate.
+class FakeClipboardDelegate : public ClipboardDelegate {
+ public:
+  FakeClipboardDelegate();
+  ~FakeClipboardDelegate() override;
+
+  void OfferClipboardData(const DataMap& data_map,
+                          OfferDataClosure callback) override;
+  void RequestClipboardData(const std::string& mime_type,
+                            DataMap* data_map,
+                            RequestDataClosure callback) override;
+  void GetAvailableMimeTypes(GetMimeTypesClosure callback) override;
+  bool IsSelectionOwner() override;
+
+ private:
+  ClipboardDelegate::DataMap offered_data_map_;
+
+  DISALLOW_COPY_AND_ASSIGN(FakeClipboardDelegate);
+};
+
+}  // namespace ui
+
+#endif  // UI_OZONE_PUBLIC_CLIPBOARD_DELEGATE_H_


### PR DESCRIPTION
It's migration for clipboard patches.
I modified some below comparing to the original patch.
1) ui/base/clipboard/clipboard.h for NoDestructor
../../base/no_destructor.h:55:20: error: calling a private constructor of class 'ui::Clipboard::FormatType'
    new (storage_) T(std::forward<Args>(args)...);
                   ^
../../ui/base/clipboard/clipboard_linux.cc:49:41: note: in instantiation of function template specialization 'base::NoDestructor<ui::Clipboard::FormatType>::NoDestructor<char const (&)[]>' requested here
  static base::NoDestructor<FormatType> type(kMimeTypeURIList);
                                        ^
../../ui/base/clipboard/clipboard.h:106:14: note: declared private here
    explicit FormatType(const std::string& native_format);

2) ui/base/clipboard/clipboard_linux.cc for unused error
../../ui/base/clipboard/clipboard_linux.cc:10:16: error: unused variable 'kClipboard' [-Werror,-Wunused-const-variable]
constexpr char kClipboard[] = "CLIPBOARD";
               ^
../../ui/base/clipboard/clipboard_linux.cc:11:16: error: unused variable 'kClipboardManager' [-Werror,-Wunused-const-variable]
constexpr char kClipboardManager[] = "CLIPBOARD_MANAGER";

PTAL.