### PR TITLE
Fix runtime error with OZONE_PLATFORM_WAYLAND_EXTERNAL

### DIFF
--- a/src/ozone/wayland/screen.cc
+++ b/src/ozone/wayland/screen.cc
@@ -15,7 +15,7 @@ WaylandScreen::WaylandScreen(wl_registry* registry, uint32_t id)
     : output_(NULL), rect_(0, 0, 0, 0) {
   static const wl_output_listener kOutputListener = {
       WaylandScreen::OutputHandleGeometry, WaylandScreen::OutputHandleMode,
-      WaylandScreen::OutputDone,
+      WaylandScreen::OutputDone, WaylandScreen::OutputScale
   };
 
   output_ = static_cast<wl_output*>(
@@ -100,6 +100,11 @@ void WaylandScreen::OutputDone(void* data, struct wl_output* wl_output) {
       WaylandDisplay::GetInstance()->OutputScreenChanged(width, height,
                                                          rotation);
   }
+}
+
+// static
+void WaylandScreen::OutputScale(void *data, struct wl_output *wl_output, int32_t factor) {
+  NOTIMPLEMENTED_LOG_ONCE();
 }
 
 }  // namespace ozonewayland

--- a/src/ozone/wayland/screen.h
+++ b/src/ozone/wayland/screen.h
@@ -52,6 +52,7 @@ class WaylandScreen {
                                int32_t refresh);
 
   static void OutputDone(void* data, struct wl_output* wl_output);
+  static void OutputScale(void *data, struct wl_output *wl_output, int32_t factor);
 
   // The Wayland output this object wraps
   wl_output* output_;

--- a/src/ozone/wayland/window.cc
+++ b/src/ozone/wayland/window.cc
@@ -79,7 +79,9 @@ void WaylandWindow::SetShellAttributes(ShellType type,
                                        WaylandShellSurface* shell_parent,
                                        int x,
                                        int y) {
+#if defined(OS_WEBOS)
   DCHECK(shell_parent && (type == POPUP));
+#endif
 
   if (!shell_surface_) {
     shell_surface_ =

--- a/src/ui/views/view.cc
+++ b/src/ui/views/view.cc
@@ -1404,7 +1404,7 @@ bool View::ExceededDragThreshold(const gfx::Vector2d& delta) {
 // Accessibility----------------------------------------------------------------
 
 ViewAccessibility& View::GetViewAccessibility() {
-#if defined(OZONE_PLATFORM_WAYLAND_EXTERNAL)
+#if defined(OS_WEBOS)
   NOTREACHED();
 #endif
   if (!view_accessibility_)


### PR DESCRIPTION
It adds wl_output_listener::scale listener and replaces
OZONE_PLATFORM_WAYLAND_EXTERNAL with OS_WEBOS.